### PR TITLE
add concise feedback forms

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,2 @@
+blank_issues_enabled: false
+contact_links: []

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -1,0 +1,27 @@
+name: 功能建议 / Feature request
+description: 提议一个具体、可说明使用场景的改进
+title: "[功能建议] "
+labels:
+  - enhancement
+body:
+  - type: textarea
+    id: use_case
+    attributes:
+      label: 使用场景 / Use case
+      description: 你在什么情况下需要这个功能？
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: 希望怎样工作 / Expected behavior
+      description: 描述你希望看到的操作和结果。
+    validations:
+      required: true
+
+  - type: textarea
+    id: current_workaround
+    attributes:
+      label: 目前怎么处理 / Current workaround
+      description: 可选；如果已有临时办法，可以写在这里。

--- a/.github/ISSUE_TEMPLATE/install-problem.yml
+++ b/.github/ISSUE_TEMPLATE/install-problem.yml
@@ -1,0 +1,83 @@
+name: 安装或更新失败 / Install problem
+description: 安装、更新、登录、额度或卸载没有正常工作
+title: "[安装问题] "
+labels:
+  - bug
+body:
+  - type: markdown
+    attributes:
+      value: |
+        请勿提交 Token、Cookie、OAuth 链接或其他凭据。
+        Do not include tokens, cookies, OAuth URLs, or other credentials.
+
+  - type: dropdown
+    id: system
+    attributes:
+      label: 系统 / System
+      options:
+        - Windows
+        - macOS
+        - Linux
+        - 其他 / Other
+    validations:
+      required: true
+
+  - type: dropdown
+    id: dsh_mode
+    attributes:
+      label: DSH 运行方式 / DSH setup
+      options:
+        - DSH-Portable
+        - npm / npx
+        - 源码运行 / From source
+        - 不确定 / Not sure
+    validations:
+      required: true
+
+  - type: input
+    id: plugin_version
+    attributes:
+      label: 插件版本 / Plugin version
+      placeholder: 例如 v0.2.8 / e.g. v0.2.8
+    validations:
+      required: true
+
+  - type: dropdown
+    id: stage
+    attributes:
+      label: 出问题的步骤 / Failing step
+      options:
+        - 安装 / Install
+        - 更新 / Update
+        - 登录 / Sign in
+        - 模型或搜索 / Models or search
+        - 额度显示 / Quota display
+        - 卸载 / Uninstall
+        - 其他 / Other
+    validations:
+      required: true
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: 发生了什么 / What happened
+      description: 写清操作步骤、预期结果和实际结果。
+    validations:
+      required: true
+
+  - type: textarea
+    id: output
+    attributes:
+      label: 错误输出 / Error output
+      description: 粘贴完整错误；先移除 Token、Cookie、OAuth 链接和其他凭据。
+      render: shell
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: safety
+    attributes:
+      label: 提交前确认 / Before submitting
+      options:
+        - label: 我已确认内容中没有 Token、Cookie、OAuth 链接或其他凭据。
+          required: true


### PR DESCRIPTION
## What changed

- add an install/update problem form with DSH setup, failing step, and sanitized error output
- add a short feature-request form
- disable unstructured blank issues

## Why

New users currently land on an empty issue page and may not know what information is useful. The forms keep feedback lightweight while collecting enough detail to act on reports.

## Checks

- issue-form YAML parsed successfully
- required fields validated
- `pnpm test` (67 passed, 1 skipped)
- `git diff --check`