### PR TITLE
docs: simplify npm install commands

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -89,17 +89,18 @@ profile and saved login.
 
 ## Existing DSH CLI
 
-When `dsh`, Node.js, and pnpm are already available, install the fixed package
-asset directly:
+When `dsh`, Node.js, and pnpm are already available, install the pinned npm
+package directly:
 
 ```sh
-dsh plugin --profile web add https://github.com/WSL043/dsh-codex-subscription/releases/download/v0.2.8/dsh-codex-subscription.tgz
+dsh plugin --profile web add dsh-codex-subscription@0.2.8
 ```
 
-Update by running the same `add` command again. When migrating from v0.2.1 by
-hand, remove `@wsl043/dsh-codex-subscription` only after the new package passes
-verification. The Windows manager performs this migration automatically and
-preserves the stored login. Uninstall the current package with:
+Update with `dsh plugin --profile web update dsh-codex-subscription`. When
+migrating from v0.2.1 by hand, remove `@wsl043/dsh-codex-subscription` only
+after the new package passes verification. The Windows manager performs this
+migration automatically and preserves the stored login. Uninstall the current
+package with:
 
 ```sh
 dsh plugin --profile web remove dsh-codex-subscription

--- a/README.en.md
+++ b/README.en.md
@@ -79,7 +79,7 @@ once and install again. Restart DSH manually after installation.
 <summary>macOS, Linux, or an existing <code>dsh</code> command</summary>
 
 ```sh
-dsh plugin --profile web add https://github.com/WSL043/dsh-codex-subscription/releases/download/v0.2.8/dsh-codex-subscription.tgz
+dsh plugin --profile web add dsh-codex-subscription
 dsh plugin --profile web list dsh-codex-subscription --depth 0
 dsh --profile web --dump-config
 ```
@@ -136,7 +136,7 @@ the two Windows first-install commands above once.
 Update and verify:
 
 ```sh
-dsh plugin --profile web add https://github.com/WSL043/dsh-codex-subscription/releases/download/v0.2.8/dsh-codex-subscription.tgz
+dsh plugin --profile web update dsh-codex-subscription
 dsh plugin --profile web list dsh-codex-subscription --depth 0
 dsh --profile web --dump-config
 ```

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ powershell.exe -NoProfile -ExecutionPolicy Bypass -File "$env:TEMP\dsh-codex.ps1
 <summary>macOS、Linux，或已有 <code>dsh</code> 命令</summary>
 
 ```sh
-dsh plugin --profile web add https://github.com/WSL043/dsh-codex-subscription/releases/download/v0.2.8/dsh-codex-subscription.tgz
+dsh plugin --profile web add dsh-codex-subscription
 dsh plugin --profile web list dsh-codex-subscription --depth 0
 dsh --profile web --dump-config
 ```
@@ -124,7 +124,7 @@ Windows 首次安装命令即可。
 更新并检查：
 
 ```sh
-dsh plugin --profile web add https://github.com/WSL043/dsh-codex-subscription/releases/download/v0.2.8/dsh-codex-subscription.tgz
+dsh plugin --profile web update dsh-codex-subscription
 dsh plugin --profile web list dsh-codex-subscription --depth 0
 dsh --profile web --dump-config
 ```

--- a/tests/release-contract.test.mjs
+++ b/tests/release-contract.test.mjs
@@ -53,7 +53,8 @@ test('shipped agent guide owns install, pinned update, verification, and uninsta
   assert.match(guide, /dsh-codex update/u)
   assert.match(guide, /dsh-codex uninstall/u)
   assert.match(guide, /DSH-Portable[\s\S]*system Node\.js or pnpm[\s\S]*per-user[\s\S]*never modifies[\s\S]*machine PATH/iu)
-  assert.match(guide, /dsh plugin --profile web add https:\/\/github\.com\/WSL043\/dsh-codex-subscription\/releases\/download\/v0\.2\.8\/dsh-codex-subscription\.tgz/u)
+  assert.match(guide, /dsh plugin --profile web add dsh-codex-subscription@0\.2\.8/u)
+  assert.match(guide, /dsh plugin --profile web update dsh-codex-subscription/u)
   assert.match(guide, /dsh plugin --profile web list dsh-codex-subscription --depth 0/u)
   assert.match(guide, /dsh --profile web --dump-config/u)
   assert.match(guide, /dsh plugin --profile web remove dsh-codex-subscription/u)
@@ -91,8 +92,10 @@ test('GitHub defaults to concise Chinese and directs Agents to their own guide',
 test('public readmes provide explicit update commands and verification', () => {
   const readmeZh = text('README.md')
   const readmeEn = text('README.en.md')
-  assert.match(readmeZh, /## 更新与卸载[\s\S]*dsh-codex update[\s\S]*dsh-codex uninstall[\s\S]*dsh plugin --profile web add https:\/\/github\.com\/WSL043\/dsh-codex-subscription\/releases\/download\/v0\.2\.8\/[\s\S]*dsh plugin --profile web list[\s\S]*dsh --profile web --dump-config[\s\S]*dsh plugin --profile web remove dsh-codex-subscription/u)
-  assert.match(readmeEn, /## Update and uninstall[\s\S]*dsh-codex update[\s\S]*dsh-codex uninstall[\s\S]*dsh plugin --profile web add https:\/\/github\.com\/WSL043\/dsh-codex-subscription\/releases\/download\/v0\.2\.8\/[\s\S]*dsh plugin --profile web list[\s\S]*dsh --profile web --dump-config[\s\S]*dsh plugin --profile web remove dsh-codex-subscription/u)
+  assert.match(readmeZh, /## 更新与卸载[\s\S]*dsh-codex update[\s\S]*dsh-codex uninstall[\s\S]*dsh plugin --profile web update dsh-codex-subscription[\s\S]*dsh plugin --profile web list[\s\S]*dsh --profile web --dump-config[\s\S]*dsh plugin --profile web remove dsh-codex-subscription/u)
+  assert.match(readmeEn, /## Update and uninstall[\s\S]*dsh-codex update[\s\S]*dsh-codex uninstall[\s\S]*dsh plugin --profile web update dsh-codex-subscription[\s\S]*dsh plugin --profile web list[\s\S]*dsh --profile web --dump-config[\s\S]*dsh plugin --profile web remove dsh-codex-subscription/u)
+  assert.match(readmeZh, /dsh plugin --profile web add dsh-codex-subscription/u)
+  assert.match(readmeEn, /dsh plugin --profile web add dsh-codex-subscription/u)
   for (const readme of [readmeZh, readmeEn]) {
     assert.match(readme, /releases\/latest\/download\/dsh-codex\.ps1/u)
     assert.doesNotMatch(readme, /dsh-codex\.ps1\?/u)


### PR DESCRIPTION
## Summary
- use the published npm package name for standard DSH installs
- document the native DSH update command
- keep Agent installs pinned and verification explicit

## Verification
- pnpm check
- isolated DSH install, update, config dump, and uninstall using dsh-codex-subscription@0.2.8