### PR TITLE
feat: ship bilingual one-line Windows setup and v1.0.1 release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,12 +35,14 @@ jobs:
         run: |
           pnpm pack --pack-destination .artifacts
           cp dsh-codex.ps1 .artifacts/dsh-codex.ps1
+          cp dsh-codex-setup.ps1 .artifacts/dsh-codex-setup.ps1
           (cd .artifacts && sha256sum dsh-codex.ps1 > dsh-codex.ps1.sha256)
           artifact="$(find .artifacts -maxdepth 1 -type f -name '*.tgz' -print -quit)"
           test -n "$artifact"
           test -s "$artifact"
           test -s .artifacts/dsh-codex.ps1
           test -s .artifacts/dsh-codex.ps1.sha256
+          test -s .artifacts/dsh-codex-setup.ps1
       - uses: actions/upload-artifact@v6
         with:
           name: dsh-codex-subscription-${{ github.sha }}
@@ -48,6 +50,7 @@ jobs:
             .artifacts/*.tgz
             .artifacts/dsh-codex.ps1
             .artifacts/dsh-codex.ps1.sha256
+            .artifacts/dsh-codex-setup.ps1
           if-no-files-found: error
           include-hidden-files: true
 
@@ -71,6 +74,6 @@ jobs:
           cache: pnpm
       - run: pnpm install --frozen-lockfile --ignore-scripts
       - name: Verify Windows installer lifecycle
-        run: node --test tests/powershell-manager.test.mjs
+        run: node --test tests/powershell-manager.test.mjs tests/powershell-setup.test.mjs
         env:
           DSH_CODEX_TEST_USER_PATH: '1'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -64,7 +64,8 @@ jobs:
           for asset in \
             dsh-codex-subscription.tgz \
             dsh-codex.ps1 \
-            dsh-codex.ps1.sha256
+            dsh-codex.ps1.sha256 \
+            dsh-codex-setup.ps1
           do
             grep -Fxq "$asset" <<<"$assets" || {
               echo "Missing release asset: $asset" >&2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,102 @@
+name: Release
+
+on:
+  workflow_run:
+    workflows: [CI]
+    types: [completed]
+
+permissions:
+  contents: write
+
+concurrency:
+  group: release-${{ github.event.workflow_run.head_sha }}
+  cancel-in-progress: false
+
+jobs:
+  release:
+    if: github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.head_branch == 'main'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.workflow_run.head_sha }}
+
+      - name: Resolve release version
+        id: version
+        shell: bash
+        run: |
+          version="$(node -p "require('./package.json').version")"
+          if [[ ! "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Invalid package version: $version" >&2
+            exit 1
+          fi
+          tag="v$version"
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          echo "tag=$tag" >> "$GITHUB_OUTPUT"
+
+      - name: Check whether release already exists
+        id: existing
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ steps.version.outputs.tag }}
+        shell: bash
+        run: |
+          if gh release view "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+            echo "needed=false" >> "$GITHUB_OUTPUT"
+            echo "$RELEASE_TAG already exists; nothing to publish."
+          else
+            echo "needed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - uses: pnpm/action-setup@v5
+        if: steps.existing.outputs.needed == 'true'
+        with:
+          version: 11.19.0
+          run_install: false
+
+      - uses: actions/setup-node@v6
+        if: steps.existing.outputs.needed == 'true'
+        with:
+          node-version: 24
+          cache: pnpm
+
+      - name: Build immutable release assets
+        if: steps.existing.outputs.needed == 'true'
+        shell: bash
+        run: |
+          pnpm install --frozen-lockfile --ignore-scripts
+          pnpm test
+          pnpm run build
+          git diff --exit-code -- lib
+          rm -rf .artifacts
+          mkdir -p .artifacts
+          pnpm pack --pack-destination .artifacts
+          package="$(find .artifacts -maxdepth 1 -type f -name '*.tgz' -print -quit)"
+          test -n "$package"
+          mv "$package" .artifacts/dsh-codex-subscription.tgz
+          cp dsh-codex.ps1 .artifacts/dsh-codex.ps1
+          cp dsh-codex-setup.ps1 .artifacts/dsh-codex-setup.ps1
+          (cd .artifacts && sha256sum dsh-codex.ps1 > dsh-codex.ps1.sha256)
+          test -s .artifacts/dsh-codex-subscription.tgz
+          test -s .artifacts/dsh-codex.ps1
+          test -s .artifacts/dsh-codex.ps1.sha256
+          test -s .artifacts/dsh-codex-setup.ps1
+
+      - name: Create GitHub Release
+        if: steps.existing.outputs.needed == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ steps.version.outputs.tag }}
+          TARGET_SHA: ${{ github.event.workflow_run.head_sha }}
+        shell: bash
+        run: |
+          gh release create "$RELEASE_TAG" \
+            .artifacts/dsh-codex-subscription.tgz \
+            .artifacts/dsh-codex.ps1 \
+            .artifacts/dsh-codex.ps1.sha256 \
+            .artifacts/dsh-codex-setup.ps1 \
+            --repo "$GITHUB_REPOSITORY" \
+            --target "$TARGET_SHA" \
+            --title "$RELEASE_TAG" \
+            --generate-notes

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,7 @@ Use this guide when a user asks an Agent to install, update, verify, or remove
 ## Safety
 
 - Confirm the target DSH profile; use `web` only when it is the user's target.
-- Use the pinned `v1.0.0` release assets for a first install, never a moving branch.
+- Use the pinned `v1.0.1` release assets for a first install, never a moving branch.
 - Never print OAuth credentials, account IDs, authorization callbacks, or the
   credential store.
 - Do not start, stop, or restart DSH without explicit permission.
@@ -51,7 +51,7 @@ the user which installation is the target.
 Download the fixed release asset to a visible file, then invoke the requested action:
 
 ```powershell
-curl.exe -fL https://github.com/WSL043/dsh-codex-subscription/releases/download/v1.0.0/dsh-codex.ps1 -o "$env:TEMP\dsh-codex.ps1"
+curl.exe -fL https://github.com/WSL043/dsh-codex-subscription/releases/download/v1.0.1/dsh-codex.ps1 -o "$env:TEMP\dsh-codex.ps1"
 powershell.exe -NoProfile -ExecutionPolicy Bypass -File "$env:TEMP\dsh-codex.ps1" Install
 ```
 
@@ -59,7 +59,7 @@ If `curl.exe` is unavailable, download the same pinned asset without executing
 remote text in memory:
 
 ```powershell
-Invoke-WebRequest -UseBasicParsing -Uri 'https://github.com/WSL043/dsh-codex-subscription/releases/download/v1.0.0/dsh-codex.ps1' -OutFile "$env:TEMP\dsh-codex.ps1"
+Invoke-WebRequest -UseBasicParsing -Uri 'https://github.com/WSL043/dsh-codex-subscription/releases/download/v1.0.1/dsh-codex.ps1' -OutFile "$env:TEMP\dsh-codex.ps1"
 powershell.exe -NoProfile -ExecutionPolicy Bypass -File "$env:TEMP\dsh-codex.ps1" Install
 ```
 
@@ -93,7 +93,7 @@ When `dsh`, Node.js, and pnpm are already available, install the pinned npm
 package directly:
 
 ```sh
-dsh plugin --profile web add dsh-codex-subscription@1.0.0
+dsh plugin --profile web add dsh-codex-subscription@1.0.1
 ```
 
 Update with `dsh plugin --profile web update dsh-codex-subscription`. When

--- a/README.en.md
+++ b/README.en.md
@@ -57,11 +57,10 @@ https://raw.githubusercontent.com/WSL043/dsh-codex-subscription/main/AGENTS.md
 
 ### Manual Windows install
 
-Open PowerShell and paste these two lines in order:
+Open PowerShell and paste this one line:
 
 ```powershell
-curl.exe -fL https://github.com/WSL043/dsh-codex-subscription/releases/latest/download/dsh-codex-setup.ps1 -o "$env:TEMP\dsh-codex-setup.ps1"
-powershell.exe -NoProfile -ExecutionPolicy Bypass -File "$env:TEMP\dsh-codex-setup.ps1"
+curl.exe -fL https://github.com/WSL043/dsh-codex-subscription/releases/latest/download/dsh-codex-setup.ps1 -o "$env:TEMP\dsh-codex-setup.ps1"; if ($LASTEXITCODE -eq 0) { powershell.exe -NoProfile -ExecutionPolicy Bypass -File "$env:TEMP\dsh-codex-setup.ps1" }
 ```
 
 The setup asks you to choose **中文（简体）** or **English** first, then discovers DSH:
@@ -155,8 +154,8 @@ Windows installer users only need these short commands:
 Update verifies the latest Release manager script with SHA-256. Uninstall removes
 the plugin and `dsh-codex` command while preserving the DSH profile, unrelated
 plugins, and saved sign-in. If an older installation has no short command, run
-the two Windows first-install commands above once; the friendly setup detects the
-existing plugin and automatically shows **Update**.
+the Windows setup line above once; the friendly setup detects the existing plugin
+and automatically shows **Update**.
 
 <details>
 <summary>Update or uninstall with an existing <code>dsh</code> command</summary>

--- a/README.en.md
+++ b/README.en.md
@@ -57,22 +57,45 @@ https://raw.githubusercontent.com/WSL043/dsh-codex-subscription/main/AGENTS.md
 
 ### Manual Windows install
 
-Open PowerShell and paste these two lines in order. They support both a normal DSH install
-and DSH-Portable. Portable users do not need a system Node.js or pnpm.
+Open PowerShell and paste these two lines in order:
+
+```powershell
+curl.exe -fL https://github.com/WSL043/dsh-codex-subscription/releases/latest/download/dsh-codex-setup.ps1 -o "$env:TEMP\dsh-codex-setup.ps1"
+powershell.exe -NoProfile -ExecutionPolicy Bypass -File "$env:TEMP\dsh-codex-setup.ps1"
+```
+
+The setup asks you to choose **中文（简体）** or **English** first, then discovers DSH:
+
+- one DSH installation: it shows the target and continues automatically;
+- multiple DSH installations: it shows a numbered list with status and paths instead of throwing a PowerShell exception;
+- no existing plugin: the operation is clearly shown as **Install**;
+- an existing current or legacy plugin: the operation is clearly shown as **Update**, using the existing safe migration path;
+- success: it shows the result and asks you to restart DSH manually; it never restarts DSH on its own.
+
+`Bypass` applies only to this child process and does not change the system
+PowerShell execution policy.
+
+Both a normal DSH installation and DSH-Portable are supported. Portable users do
+not need a system Node.js or pnpm, and administrator access is not required. The
+friendly setup downloads the core manager, verifies its Release SHA-256, then
+lets the existing manager perform installation, update, verification, and PATH
+handling.
+
+<details>
+<summary>Non-interactive / compatibility install</summary>
+
+For scripting, Agent workflows, or an explicit `Install` action, the original
+core manager remains available:
 
 ```powershell
 curl.exe -fL https://github.com/WSL043/dsh-codex-subscription/releases/latest/download/dsh-codex.ps1 -o "$env:TEMP\dsh-codex.ps1"
 powershell.exe -NoProfile -ExecutionPolicy Bypass -File "$env:TEMP\dsh-codex.ps1" Install
 ```
 
-`Bypass` applies only to this child process and does not change the system
-PowerShell execution policy.
+When more than one DSH-Portable copy exists, pass `-PortableRoot` explicitly.
+This entry point stays non-interactive for automation.
 
-The commands support both a normal DSH installation and DSH-Portable. Portable
-users do not need a separate Node.js or pnpm installation, and no administrator
-access is required. The installer finds DSH, verifies the result, and adds the
-per-user `dsh-codex` command. It does not change the system execution policy or
-restart DSH on its own.
+</details>
 
 If the portable folder was renamed or moved, start the intended DSH-Portable copy
 once and install again. Restart DSH manually after installation.
@@ -132,7 +155,8 @@ Windows installer users only need these short commands:
 Update verifies the latest Release manager script with SHA-256. Uninstall removes
 the plugin and `dsh-codex` command while preserving the DSH profile, unrelated
 plugins, and saved sign-in. If an older installation has no short command, run
-the two Windows first-install commands above once.
+the two Windows first-install commands above once; the friendly setup detects the
+existing plugin and automatically shows **Update**.
 
 <details>
 <summary>Update or uninstall with an existing <code>dsh</code> command</summary>
@@ -166,9 +190,8 @@ If DSH is running, restart it manually after installation or update.
 
 - If `dsh-codex` is not found after installation, close and reopen PowerShell;
 - If DSH-Portable is not found, start the intended portable copy once and retry;
-- If `curl.exe` is missing, more than one DSH is present, or the command still
-  fails, send the Agent guide URL above to an Agent. Do not change the machine
-  PATH or execution policy, and do not delete a profile to force an install.
+- If multiple DSH installations are found, choose the intended one from the numbered list;
+- If `curl.exe` is missing or setup still fails, send the Agent guide URL above to an Agent. Do not change the machine PATH or execution policy, and do not delete a profile to force an install.
 
 ## Boundaries and support
 

--- a/README.md
+++ b/README.md
@@ -54,11 +54,10 @@ https://raw.githubusercontent.com/WSL043/dsh-codex-subscription/main/AGENTS.md
 
 ### Windows 手动安装
 
-打开 PowerShell，依次粘贴下面两行：
+打开 PowerShell，只需要复制这一行：
 
 ```powershell
-curl.exe -fL https://github.com/WSL043/dsh-codex-subscription/releases/latest/download/dsh-codex-setup.ps1 -o "$env:TEMP\dsh-codex-setup.ps1"
-powershell.exe -NoProfile -ExecutionPolicy Bypass -File "$env:TEMP\dsh-codex-setup.ps1"
+curl.exe -fL https://github.com/WSL043/dsh-codex-subscription/releases/latest/download/dsh-codex-setup.ps1 -o "$env:TEMP\dsh-codex-setup.ps1"; if ($LASTEXITCODE -eq 0) { powershell.exe -NoProfile -ExecutionPolicy Bypass -File "$env:TEMP\dsh-codex-setup.ps1" }
 ```
 
 安装助手会先让你选择 **中文（简体）** 或 **English**，然后自动寻找 DSH：
@@ -200,11 +199,10 @@ service.
 [installation guide](https://raw.githubusercontent.com/WSL043/dsh-codex-subscription/main/AGENTS.md)
 to your Agent.
 
-**Windows install:** open PowerShell and run these two lines:
+**Windows install:** open PowerShell and run this one line:
 
 ```powershell
-curl.exe -fL https://github.com/WSL043/dsh-codex-subscription/releases/latest/download/dsh-codex-setup.ps1 -o "$env:TEMP\dsh-codex-setup.ps1"
-powershell.exe -NoProfile -ExecutionPolicy Bypass -File "$env:TEMP\dsh-codex-setup.ps1"
+curl.exe -fL https://github.com/WSL043/dsh-codex-subscription/releases/latest/download/dsh-codex-setup.ps1 -o "$env:TEMP\dsh-codex-setup.ps1"; if ($LASTEXITCODE -eq 0) { powershell.exe -NoProfile -ExecutionPolicy Bypass -File "$env:TEMP\dsh-codex-setup.ps1" }
 ```
 
 The setup asks for Chinese or English first, turns multiple DSH copies into a

--- a/README.md
+++ b/README.md
@@ -57,13 +57,35 @@ https://raw.githubusercontent.com/WSL043/dsh-codex-subscription/main/AGENTS.md
 打开 PowerShell，依次粘贴下面两行：
 
 ```powershell
+curl.exe -fL https://github.com/WSL043/dsh-codex-subscription/releases/latest/download/dsh-codex-setup.ps1 -o "$env:TEMP\dsh-codex-setup.ps1"
+powershell.exe -NoProfile -ExecutionPolicy Bypass -File "$env:TEMP\dsh-codex-setup.ps1"
+```
+
+安装助手会先让你选择 **中文（简体）** 或 **English**，然后自动寻找 DSH：
+
+- 只找到一个 DSH：直接显示目标并继续；
+- 找到多个 DSH：显示编号、状态和路径，让你输入编号选择，不再直接抛英文报错；
+- 没有安装过插件：明确显示 **安装**；
+- 已经安装当前版或旧版插件：明确显示 **更新**，旧包会按原有安全迁移流程处理；
+- 成功后只提示结果和需要手动重启 DSH，不会擅自重启程序。
+
+普通安装版和 DSH-Portable 都能使用。便携版不需要另装 Node.js 或 pnpm，整个过程不需要
+管理员权限。安装助手下载核心管理脚本后会校验 Release 提供的 SHA-256，再交给原有管理器
+执行安装、更新、验证和 PATH 处理。
+
+<details>
+<summary>非交互安装 / 兼容旧方式</summary>
+
+需要脚本化安装、Agent 操作，或想明确指定 `Install` 时，仍然可以使用原来的核心管理器：
+
+```powershell
 curl.exe -fL https://github.com/WSL043/dsh-codex-subscription/releases/latest/download/dsh-codex.ps1 -o "$env:TEMP\dsh-codex.ps1"
 powershell.exe -NoProfile -ExecutionPolicy Bypass -File "$env:TEMP\dsh-codex.ps1" Install
 ```
 
-普通安装版和 DSH-Portable 都能使用。便携版不需要另装 Node.js 或 pnpm，整个过程不需要
-管理员权限。安装器会自动寻找 DSH、验证安装结果，并添加当前用户的 `dsh-codex` 命令；
-它不会修改系统执行策略或擅自重启 DSH。
+如果有多个 DSH-Portable，也可以继续显式传入 `-PortableRoot`。这个入口保持非交互，适合自动化。
+
+</details>
 
 如果便携文件夹改过名字或位置，先启动一次正确的 DSH-Portable，再执行安装。完成后手动
 重启 DSH，让插件生效。
@@ -120,7 +142,7 @@ Windows 安装器用户只需要两条短命令：
 
 更新会校验最新 Release 管理脚本的 SHA-256。卸载会移除插件和 `dsh-codex` 命令，但保留
 DSH profile、其他插件和已保存的登录信息。旧版本如果还没有短命令，重新执行一次上面的
-Windows 首次安装命令即可。
+Windows 首次安装命令即可；安装助手检测到已有插件时会自动显示并执行“更新”。
 
 <details>
 <summary>使用现有 <code>dsh</code> 命令更新或卸载</summary>
@@ -153,8 +175,8 @@ dsh plugin --profile web remove @wsl043/dsh-codex-subscription
 
 - 找不到 `dsh-codex`：关闭并重新打开 PowerShell；
 - 找不到 DSH-Portable：先启动一次正确的便携版，再重新安装；
-- 没有 `curl.exe`、检测到多个 DSH，或仍然失败：把 Agent 文档链接发给 Agent，
-  不要自行修改系统 PATH、执行策略或删除 profile。
+- 检测到多个 DSH：新版安装助手会列出编号和路径，选你准备使用的那个即可；
+- 没有 `curl.exe` 或仍然失败：把 Agent 文档链接发给 Agent，不要自行修改系统 PATH、执行策略或删除 profile。
 
 ## 边界与支持
 
@@ -181,12 +203,14 @@ to your Agent.
 **Windows install:** open PowerShell and run these two lines:
 
 ```powershell
-curl.exe -fL https://github.com/WSL043/dsh-codex-subscription/releases/latest/download/dsh-codex.ps1 -o "$env:TEMP\dsh-codex.ps1"
-powershell.exe -NoProfile -ExecutionPolicy Bypass -File "$env:TEMP\dsh-codex.ps1" Install
+curl.exe -fL https://github.com/WSL043/dsh-codex-subscription/releases/latest/download/dsh-codex-setup.ps1 -o "$env:TEMP\dsh-codex-setup.ps1"
+powershell.exe -NoProfile -ExecutionPolicy Bypass -File "$env:TEMP\dsh-codex-setup.ps1"
 ```
 
-DSH-Portable is supported without a separate Node.js or pnpm installation.
-After the first install, use `dsh-codex update` to update and
+The setup asks for Chinese or English first, turns multiple DSH copies into a
+numbered choice, and automatically shows **Install** or **Update** based on the
+selected DSH. DSH-Portable is supported without a separate Node.js or pnpm
+installation. After the first install, use `dsh-codex update` to update and
 `dsh-codex uninstall` to remove it. Open **Settings -> Codex**, sign in with a
 ChatGPT account that has Codex access, choose a search source, and select a Codex
 model. For full usage and troubleshooting, see the

--- a/dsh-codex-setup.ps1
+++ b/dsh-codex-setup.ps1
@@ -287,9 +287,11 @@ function Get-TargetCandidates {
         Add-PortableCandidate -Candidates $candidates -ByRoot $byRoot -Layout $currentLayout -Source Current
     }
     foreach ($layout in @(Find-RunningPortables)) {
+        if ($null -eq $layout) { continue }
         Add-PortableCandidate -Candidates $candidates -ByRoot $byRoot -Layout $layout -Source Running
     }
     foreach ($layout in @(Find-CommonPortables)) {
+        if ($null -eq $layout) { continue }
         Add-PortableCandidate -Candidates $candidates -ByRoot $byRoot -Layout $layout -Source Common
     }
 

--- a/dsh-codex-setup.ps1
+++ b/dsh-codex-setup.ps1
@@ -1,0 +1,623 @@
+﻿[CmdletBinding()]
+param(
+    [ValidateSet('Auto', 'Install', 'Update')]
+    [string] $Action = 'Auto',
+
+    [ValidateSet('zh-CN', 'en-US')]
+    [string] $Language,
+
+    [ValidatePattern('^[A-Za-z0-9._-]+$')]
+    [string] $Profile = 'web',
+
+    [string] $PortableRoot,
+
+    [string] $ManagerPath,
+
+    [switch] $DryRun
+)
+
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version 2.0
+$Utf8NoBom = New-Object System.Text.UTF8Encoding($false)
+[Console]::OutputEncoding = $Utf8NoBom
+$OutputEncoding = $Utf8NoBom
+
+$PackageName = 'dsh-codex-subscription'
+$LegacyPackageName = '@wsl043/dsh-codex-subscription'
+$ReleaseApi = 'https://api.github.com/repos/WSL043/dsh-codex-subscription/releases/latest'
+$ReleaseBase = 'https://github.com/WSL043/dsh-codex-subscription/releases/download'
+
+$Messages = @{
+    'zh-CN' = @{
+        Banner = 'DSH Codex Subscription 安装助手'
+        Searching = '正在查找这台电脑上的 DSH...'
+        MultipleFound = '检测到多个 DSH。请选择要安装或更新的那个：'
+        Running = '正在运行'
+        Current = '当前目录'
+        Detected = '已检测到'
+        Portable = 'DSH-Portable'
+        Global = 'DSH'
+        Choose = '输入编号，或输入 Q 退出'
+        InvalidChoice = '请输入列表中的编号。'
+        NoDsh = '没有找到可用的 DSH。请先打开一次 DSH / DSH-Portable，然后重新运行安装助手。'
+        GlobalNeedsNode = '找到了 dsh 命令，但没有找到可用的 Node.js。请改用 DSH-Portable，或修复现有 DSH 安装。'
+        Selected = '目标'
+        CheckingState = '正在检查是否已经安装 Codex Subscription...'
+        Install = '安装'
+        Update = '更新'
+        Operation = '操作'
+        CurrentVersion = '当前版本'
+        NotInstalled = '未安装'
+        LegacyInstalled = '检测到旧版插件，将执行迁移更新'
+        Downloading = '正在获取并校验最新安装组件...'
+        Installing = '正在安装，请不要关闭窗口...'
+        Updating = '正在更新，请不要关闭窗口...'
+        InstallSuccess = '安装完成。'
+        UpdateSuccess = '更新完成。'
+        Restart = '请手动重启 DSH，让插件生效。'
+        NextUpdate = '以后更新可以直接运行：dsh-codex update'
+        Failure = '操作没有完成。'
+        Help = '把上面的错误信息发给 Agent 即可，不需要自己改 PATH、执行策略或删除 DSH 配置。'
+        StatusFailure = '无法确认当前插件状态，为避免误判，安装助手已停止。'
+        LocalManager = '正在使用指定的本地安装组件。'
+    }
+    'en-US' = @{
+        Banner = 'DSH Codex Subscription Setup'
+        Searching = 'Looking for DSH installations on this computer...'
+        MultipleFound = 'More than one DSH installation was found. Choose the one to install or update:'
+        Running = 'running'
+        Current = 'current folder'
+        Detected = 'detected'
+        Portable = 'DSH-Portable'
+        Global = 'DSH'
+        Choose = 'Enter a number, or Q to quit'
+        InvalidChoice = 'Enter one of the numbers shown above.'
+        NoDsh = 'No usable DSH installation was found. Start DSH / DSH-Portable once, then run this setup again.'
+        GlobalNeedsNode = 'A dsh command was found, but a usable Node.js was not. Use DSH-Portable or repair the existing DSH installation.'
+        Selected = 'Target'
+        CheckingState = 'Checking whether Codex Subscription is already installed...'
+        Install = 'Install'
+        Update = 'Update'
+        Operation = 'Operation'
+        CurrentVersion = 'Current version'
+        NotInstalled = 'not installed'
+        LegacyInstalled = 'A legacy plugin was found and will be migrated during the update'
+        Downloading = 'Downloading and verifying the latest installer component...'
+        Installing = 'Installing. Do not close this window...'
+        Updating = 'Updating. Do not close this window...'
+        InstallSuccess = 'Installation completed.'
+        UpdateSuccess = 'Update completed.'
+        Restart = 'Restart DSH manually to load the plugin.'
+        NextUpdate = 'For future updates, run: dsh-codex update'
+        Failure = 'The operation did not complete.'
+        Help = 'Send the error above to an Agent. You do not need to edit PATH, change execution policy, or delete a DSH profile.'
+        StatusFailure = 'The current plugin state could not be confirmed, so setup stopped instead of guessing.'
+        LocalManager = 'Using the specified local installer component.'
+    }
+}
+
+function Select-SetupLanguage {
+    if ($Language) { return $Language }
+
+    Write-Host ''
+    Write-Host 'DSH Codex Subscription'
+    Write-Host '1. 中文（简体）'
+    Write-Host '2. English'
+    while ($true) {
+        $choice = Read-Host '请选择语言 / Select language [1]'
+        if (-not $choice -or $choice.Trim() -eq '1') { return 'zh-CN' }
+        if ($choice.Trim() -eq '2') { return 'en-US' }
+        Write-Host '请输入 1 或 2 / Please enter 1 or 2.' -ForegroundColor Yellow
+    }
+}
+
+$script:SelectedLanguage = Select-SetupLanguage
+
+function T {
+    param([Parameter(Mandatory = $true)][string] $Key)
+    return [string] $Messages[$script:SelectedLanguage][$Key]
+}
+
+function Resolve-FullPath {
+    param([Parameter(Mandatory = $true)][string] $Path)
+    return [System.IO.Path]::GetFullPath([Environment]::ExpandEnvironmentVariables($Path))
+}
+
+function Test-SamePath {
+    param(
+        [Parameter(Mandatory = $true)][string] $Left,
+        [Parameter(Mandatory = $true)][string] $Right
+    )
+    try {
+        $leftPath = (Resolve-FullPath $Left).TrimEnd('\')
+        $rightPath = (Resolve-FullPath $Right).TrimEnd('\')
+        return [string]::Equals($leftPath, $rightPath, [System.StringComparison]::OrdinalIgnoreCase)
+    } catch {
+        return [string]::Equals($Left.Trim(), $Right.Trim(), [System.StringComparison]::OrdinalIgnoreCase)
+    }
+}
+
+function Get-PortableLayout {
+    param([Parameter(Mandatory = $true)][string] $Root)
+
+    $resolvedRoot = Resolve-FullPath $Root
+    $node = Join-Path $resolvedRoot 'runtime\node\node.exe'
+    $dsh = Join-Path $resolvedRoot 'app\node_modules\@deepseek-ai\dsh\lib\bin.js'
+    $portableCli = Join-Path $resolvedRoot 'dsh.exe'
+    if (-not (Test-Path -LiteralPath $node -PathType Leaf) -or
+        -not (Test-Path -LiteralPath $dsh -PathType Leaf)) {
+        return $null
+    }
+
+    $stateRoot = $resolvedRoot
+    $installedMode = Join-Path $resolvedRoot 'installed-mode.json'
+    if (Test-Path -LiteralPath $installedMode -PathType Leaf) {
+        $mode = Get-Content -LiteralPath $installedMode -Raw | ConvertFrom-Json
+        if (-not $mode.stateRoot) { throw 'installed-mode.json is missing stateRoot.' }
+        $stateRoot = Resolve-FullPath ([string] $mode.stateRoot)
+    }
+
+    return [pscustomobject]@{
+        Root = $resolvedRoot
+        StateRoot = $stateRoot
+        Node = $node
+        Dsh = $dsh
+        PortableCli = if (Test-Path -LiteralPath $portableCli -PathType Leaf) { $portableCli } else { $null }
+        DshHome = Join-Path $stateRoot 'data\dsh-home'
+    }
+}
+
+function Find-PortableFromCurrentDirectory {
+    $directory = [System.IO.DirectoryInfo]::new((Get-Location).Path)
+    while ($null -ne $directory) {
+        try {
+            $layout = Get-PortableLayout $directory.FullName
+            if ($null -ne $layout) { return $layout }
+        } catch {
+            # A broken unrelated candidate must not hide other valid installations.
+        }
+        $directory = $directory.Parent
+    }
+    return $null
+}
+
+function Find-RunningPortables {
+    try {
+        $processes = Get-CimInstance Win32_Process -Filter "Name = 'node.exe'" -ErrorAction Stop
+        foreach ($process in $processes) {
+            $executable = [string] $process.ExecutablePath
+            if (-not $executable) { continue }
+            $nodeDirectory = Split-Path -Parent $executable
+            $runtimeDirectory = Split-Path -Parent $nodeDirectory
+            $root = Split-Path -Parent $runtimeDirectory
+            try {
+                $layout = Get-PortableLayout $root
+            } catch {
+                continue
+            }
+            if ($null -eq $layout) { continue }
+            if (-not (Test-SamePath -Left $executable -Right $layout.Node)) { continue }
+            $commandLine = [string] $process.CommandLine
+            if ($commandLine -match '(?i)@deepseek-ai[\\/]dsh[\\/]lib[\\/]bin\.js') {
+                Write-Output $layout
+            }
+        }
+    } catch {
+        # Running-process discovery is only one location hint.
+    }
+    return $null
+}
+
+function Find-CommonPortables {
+    $candidates = New-Object System.Collections.Generic.List[string]
+    if ($env:LOCALAPPDATA) {
+        $candidates.Add((Join-Path $env:LOCALAPPDATA 'Programs\DeepSeek-Herness'))
+    }
+    if ($env:USERPROFILE) {
+        $candidates.Add((Join-Path $env:USERPROFILE 'Downloads\DSH-Portable'))
+        $candidates.Add((Join-Path $env:USERPROFILE 'Desktop\DSH-Portable'))
+        foreach ($parent in @(
+            (Join-Path $env:USERPROFILE 'Downloads'),
+            (Join-Path $env:USERPROFILE 'Desktop')
+        )) {
+            if (-not (Test-Path -LiteralPath $parent -PathType Container)) { continue }
+            foreach ($directory in Get-ChildItem -LiteralPath $parent -Directory -ErrorAction SilentlyContinue) {
+                $candidates.Add($directory.FullName)
+            }
+        }
+    }
+
+    foreach ($candidate in $candidates | Select-Object -Unique) {
+        try {
+            $layout = Get-PortableLayout $candidate
+            if ($null -ne $layout) { Write-Output $layout }
+        } catch {
+            # Keep looking for another valid installation.
+        }
+    }
+}
+
+function Add-PortableCandidate {
+    param(
+        [Parameter(Mandatory = $true)] $Candidates,
+        [Parameter(Mandatory = $true)][hashtable] $ByRoot,
+        [Parameter(Mandatory = $true)] $Layout,
+        [ValidateSet('Current', 'Running', 'Common')][string] $Source
+    )
+
+    $key = $Layout.Root.TrimEnd('\').ToLowerInvariant()
+    if ($ByRoot.ContainsKey($key)) {
+        $candidate = $ByRoot[$key]
+    } else {
+        $candidate = [pscustomobject]@{
+            Mode = 'portable'
+            Root = $Layout.Root
+            Layout = $Layout
+            Executable = if ($null -ne $Layout.PortableCli) { $Layout.PortableCli } else { $Layout.Node }
+            Node = $Layout.Node
+            UsesPortableCli = $null -ne $Layout.PortableCli
+            Running = $false
+            Current = $false
+            Common = $false
+        }
+        [void] $Candidates.Add($candidate)
+        $ByRoot[$key] = $candidate
+    }
+
+    if ($Source -eq 'Current') { $candidate.Current = $true }
+    if ($Source -eq 'Running') { $candidate.Running = $true }
+    if ($Source -eq 'Common') { $candidate.Common = $true }
+}
+
+$script:GlobalDshNeedsNode = $false
+
+function Get-TargetCandidates {
+    $candidates = New-Object System.Collections.ArrayList
+    $byRoot = @{}
+
+    if ($PortableRoot) {
+        $layout = Get-PortableLayout $PortableRoot
+        if ($null -eq $layout) { throw "The selected DSH-Portable folder is incomplete: $PortableRoot" }
+        Add-PortableCandidate -Candidates $candidates -ByRoot $byRoot -Layout $layout -Source Current
+        return @($candidates)
+    }
+
+    $currentLayout = Find-PortableFromCurrentDirectory
+    if ($null -ne $currentLayout) {
+        Add-PortableCandidate -Candidates $candidates -ByRoot $byRoot -Layout $currentLayout -Source Current
+    }
+    foreach ($layout in @(Find-RunningPortables)) {
+        Add-PortableCandidate -Candidates $candidates -ByRoot $byRoot -Layout $layout -Source Running
+    }
+    foreach ($layout in @(Find-CommonPortables)) {
+        Add-PortableCandidate -Candidates $candidates -ByRoot $byRoot -Layout $layout -Source Common
+    }
+
+    $globalDsh = Get-Command dsh -ErrorAction SilentlyContinue
+    if ($null -ne $globalDsh) {
+        $alreadyPortable = $false
+        foreach ($candidate in @($candidates)) {
+            if ($candidate.UsesPortableCli -and (Test-SamePath -Left $candidate.Executable -Right $globalDsh.Source)) {
+                $alreadyPortable = $true
+                break
+            }
+        }
+        if (-not $alreadyPortable) {
+            $globalNode = Get-Command node -ErrorAction SilentlyContinue
+            if ($null -eq $globalNode) {
+                $script:GlobalDshNeedsNode = $true
+            } else {
+                [void] $candidates.Add([pscustomobject]@{
+                    Mode = 'global'
+                    Root = $null
+                    Layout = $null
+                    Executable = $globalDsh.Source
+                    Node = $globalNode.Source
+                    UsesPortableCli = $false
+                    Running = $false
+                    Current = $false
+                    Common = $true
+                })
+            }
+        }
+    }
+
+    return @($candidates)
+}
+
+function Get-CandidateLabel {
+    param([Parameter(Mandatory = $true)] $Candidate)
+
+    $kind = if ($Candidate.Mode -eq 'portable') { T 'Portable' } else { T 'Global' }
+    $notes = New-Object System.Collections.Generic.List[string]
+    if ($Candidate.Running) { $notes.Add((T 'Running')) }
+    if ($Candidate.Current) { $notes.Add((T 'Current')) }
+    if ($notes.Count -eq 0) { $notes.Add((T 'Detected')) }
+    $separator = if ($script:SelectedLanguage -eq 'zh-CN') { '、' } else { ', ' }
+    return "$kind ($($notes -join $separator))"
+}
+
+function Select-Target {
+    param([Parameter(Mandatory = $true)][object[]] $Candidates)
+
+    if ($Candidates.Count -eq 0) {
+        if ($script:GlobalDshNeedsNode) { throw (T 'GlobalNeedsNode') }
+        throw (T 'NoDsh')
+    }
+    if ($Candidates.Count -eq 1) { return $Candidates[0] }
+
+    Write-Host ''
+    Write-Host (T 'MultipleFound') -ForegroundColor Cyan
+    for ($index = 0; $index -lt $Candidates.Count; $index++) {
+        $candidate = $Candidates[$index]
+        $location = if ($candidate.Mode -eq 'portable') { $candidate.Root } else { $candidate.Executable }
+        Write-Host ("[{0}] {1}" -f ($index + 1), (Get-CandidateLabel $candidate))
+        Write-Host ("    {0}" -f $location)
+    }
+
+    while ($true) {
+        $choice = Read-Host (T 'Choose')
+        if ($choice -and $choice.Trim() -match '^(?i)q$') { exit 0 }
+        $selectedNumber = 0
+        if ([int]::TryParse(([string] $choice).Trim(), [ref] $selectedNumber) -and
+            $selectedNumber -ge 1 -and $selectedNumber -le $Candidates.Count) {
+            return $Candidates[$selectedNumber - 1]
+        }
+        Write-Host (T 'InvalidChoice') -ForegroundColor Yellow
+    }
+}
+
+function Invoke-TargetDshCapture {
+    param(
+        [Parameter(Mandatory = $true)] $Target,
+        [Parameter(Mandatory = $true)][string[]] $Arguments
+    )
+
+    $oldDshHome = $env:DSH_HOME
+    $oldDshPortable = $env:DSH_PORTABLE
+    $oldTelemetry = $env:DSH_TELEMETRY_MODE
+    try {
+        if ($Target.Mode -eq 'portable') {
+            $env:DSH_HOME = $Target.Layout.DshHome
+            $env:DSH_PORTABLE = '1'
+            $env:DSH_TELEMETRY_MODE = 'DISABLED'
+        }
+        $allArguments = if ($Target.Mode -eq 'portable' -and -not $Target.UsesPortableCli) {
+            @($Target.Layout.Dsh) + $Arguments
+        } else {
+            $Arguments
+        }
+        $output = & $Target.Executable @allArguments 2>&1
+        $exitCode = $LASTEXITCODE
+        if ($exitCode -ne 0) {
+            throw "dsh returned exit code $exitCode."
+        }
+        return ($output -join [Environment]::NewLine)
+    } finally {
+        $env:DSH_HOME = $oldDshHome
+        $env:DSH_PORTABLE = $oldDshPortable
+        $env:DSH_TELEMETRY_MODE = $oldTelemetry
+    }
+}
+
+function Get-InstalledPackageStatus {
+    param([Parameter(Mandatory = $true)] $Target)
+
+    if ($Target.Mode -eq 'portable' -and -not (Test-Path -LiteralPath $Target.Layout.DshHome -PathType Container)) {
+        return [pscustomobject]@{
+            HasCurrent = $false
+            CurrentVersion = $null
+            HasLegacy = $false
+            LegacyVersion = $null
+        }
+    }
+
+    $json = Invoke-TargetDshCapture -Target $Target -Arguments @(
+        'plugin', '--profile', $Profile, 'list', '--depth', '0', '--json', '--loglevel', 'error'
+    )
+    try {
+        $parsedProjects = $json | ConvertFrom-Json
+        $projects = @($parsedProjects)
+    } catch {
+        throw 'DSH returned an unreadable plugin list.'
+    }
+
+    $hasCurrent = $false
+    $currentVersion = $null
+    $hasLegacy = $false
+    $legacyVersion = $null
+    foreach ($project in $projects) {
+        $dependenciesProperty = $project.PSObject.Properties['dependencies']
+        if ($null -eq $dependenciesProperty -or $null -eq $dependenciesProperty.Value) { continue }
+        foreach ($property in $dependenciesProperty.Value.PSObject.Properties) {
+            $version = $null
+            if ($null -ne $property.Value) {
+                $versionProperty = $property.Value.PSObject.Properties['version']
+                if ($null -ne $versionProperty -and $null -ne $versionProperty.Value) {
+                    $version = [string] $versionProperty.Value
+                }
+            }
+            if ([string]::Equals([string] $property.Name, $PackageName, [System.StringComparison]::OrdinalIgnoreCase)) {
+                $hasCurrent = $true
+                $currentVersion = $version
+            }
+            if ([string]::Equals([string] $property.Name, $LegacyPackageName, [System.StringComparison]::OrdinalIgnoreCase)) {
+                $hasLegacy = $true
+                $legacyVersion = $version
+            }
+        }
+    }
+
+    return [pscustomobject]@{
+        HasCurrent = $hasCurrent
+        CurrentVersion = $currentVersion
+        HasLegacy = $hasLegacy
+        LegacyVersion = $legacyVersion
+    }
+}
+
+function Get-FileDigest {
+    param(
+        [Parameter(Mandatory = $true)][string] $Path,
+        [ValidateSet('SHA256')][string] $Algorithm = 'SHA256'
+    )
+
+    $hasher = [System.Security.Cryptography.SHA256]::Create()
+    $stream = [System.IO.File]::OpenRead($Path)
+    try {
+        return ([System.BitConverter]::ToString($hasher.ComputeHash($stream))).Replace('-', '')
+    } finally {
+        $stream.Dispose()
+        $hasher.Dispose()
+    }
+}
+
+function Get-VerifiedManager {
+    if ($ManagerPath) {
+        $resolvedManager = Resolve-FullPath $ManagerPath
+        if (-not (Test-Path -LiteralPath $resolvedManager -PathType Leaf)) {
+            throw "Manager file not found: $resolvedManager"
+        }
+        Write-Host (T 'LocalManager')
+        return [pscustomobject]@{ Path = $resolvedManager; Stage = $null; Tag = 'local' }
+    }
+
+    Write-Host (T 'Downloading')
+    $releaseSeparator = if ($ReleaseApi.Contains('?')) { '&' } else { '?' }
+    $releaseUri = $ReleaseApi + $releaseSeparator + 'cache_bust=' + [DateTime]::UtcNow.Ticks
+    $releaseResponse = Invoke-WebRequest -UseBasicParsing -Uri $releaseUri -Headers @{
+        Accept = 'application/vnd.github+json'
+        'Cache-Control' = 'no-cache'
+        Pragma = 'no-cache'
+        'User-Agent' = 'dsh-codex-setup'
+    }
+    try {
+        $release = $releaseResponse.Content | ConvertFrom-Json
+    } catch {
+        throw 'GitHub returned unreadable latest-release metadata.'
+    }
+    $tag = [string] $release.tag_name
+    if ($tag -notmatch '^v[0-9]+\.[0-9]+\.[0-9]+(?:-[0-9A-Za-z.-]+)?$') {
+        throw "GitHub returned an invalid release tag: $tag"
+    }
+
+    $stage = Join-Path ([System.IO.Path]::GetTempPath()) ('dsh-codex-setup-' + [guid]::NewGuid().ToString('N'))
+    $manager = Join-Path $stage 'dsh-codex.ps1'
+    $checksumFile = Join-Path $stage 'dsh-codex.ps1.sha256'
+    New-Item -ItemType Directory -Path $stage | Out-Null
+    try {
+        $assetBase = "$ReleaseBase/$tag"
+        Invoke-WebRequest -UseBasicParsing -Uri "$assetBase/dsh-codex.ps1" -OutFile $manager
+        Invoke-WebRequest -UseBasicParsing -Uri "$assetBase/dsh-codex.ps1.sha256" -OutFile $checksumFile
+        $checksumText = Get-Content -LiteralPath $checksumFile -Raw
+        $match = [regex]::Match($checksumText, '(?im)^\s*([a-f0-9]{64})\s+\*?dsh-codex\.ps1\s*$')
+        if (-not $match.Success) { throw 'The release manager checksum file is invalid.' }
+        $expectedHash = $match.Groups[1].Value.ToUpperInvariant()
+        $actualHash = Get-FileDigest -Path $manager
+        if ($actualHash -ne $expectedHash) {
+            throw "Release manager checksum mismatch. Expected $expectedHash, received $actualHash."
+        }
+        return [pscustomobject]@{ Path = $manager; Stage = $stage; Tag = $tag }
+    } catch {
+        if (Test-Path -LiteralPath $stage) {
+            Remove-Item -LiteralPath $stage -Recurse -Force -ErrorAction SilentlyContinue
+        }
+        throw
+    }
+}
+
+function Invoke-Setup {
+    Write-Host ''
+    Write-Host (T 'Banner') -ForegroundColor Cyan
+    Write-Host (T 'Searching')
+
+    $candidates = @(Get-TargetCandidates)
+    $target = Select-Target -Candidates $candidates
+    $targetLocation = if ($target.Mode -eq 'portable') { $target.Root } else { $target.Executable }
+    Write-Host ("{0}: {1}" -f (T 'Selected'), $targetLocation)
+    Write-Host (T 'CheckingState')
+
+    try {
+        $status = Get-InstalledPackageStatus -Target $target
+    } catch {
+        throw ((T 'StatusFailure') + ' ' + $_.Exception.Message)
+    }
+
+    $isInstalled = $status.HasCurrent -or $status.HasLegacy
+    $effectiveAction = $Action
+    if ($effectiveAction -eq 'Auto') {
+        $effectiveAction = if ($isInstalled) { 'Update' } else { 'Install' }
+    }
+
+    $operationText = if ($effectiveAction -eq 'Update') { T 'Update' } else { T 'Install' }
+    Write-Host ("{0}: {1}" -f (T 'Operation'), $operationText) -ForegroundColor Yellow
+    if ($status.HasCurrent) {
+        $version = if ($status.CurrentVersion) { $status.CurrentVersion } else { 'unknown' }
+        Write-Host ("{0}: {1}" -f (T 'CurrentVersion'), $version)
+    } elseif ($status.HasLegacy) {
+        Write-Host (T 'LegacyInstalled')
+    } else {
+        Write-Host ("{0}: {1}" -f (T 'CurrentVersion'), (T 'NotInstalled'))
+    }
+
+    if ($DryRun) {
+        [ordered]@{
+            language = $script:SelectedLanguage
+            candidateCount = $candidates.Count
+            mode = $target.Mode
+            target = $targetLocation
+            action = $effectiveAction
+            installed = $isInstalled
+            installedVersion = if ($status.HasCurrent) { $status.CurrentVersion } elseif ($status.HasLegacy) { $status.LegacyVersion } else { $null }
+        } | ConvertTo-Json -Compress
+        return
+    }
+
+    $manager = Get-VerifiedManager
+    $log = Join-Path ([System.IO.Path]::GetTempPath()) ('dsh-codex-setup-log-' + [guid]::NewGuid().ToString('N') + '.txt')
+    try {
+        if ($effectiveAction -eq 'Update') {
+            Write-Host (T 'Updating')
+        } else {
+            Write-Host (T 'Installing')
+        }
+
+        $managerArguments = @('-Action', $effectiveAction, '-Profile', $Profile)
+        if ($target.Mode -eq 'portable') {
+            $managerArguments += @('-PortableRoot', $target.Root)
+        }
+
+        try {
+            & $manager.Path @managerArguments *> $log
+        } catch {
+            throw $_.Exception.Message
+        }
+
+        Write-Host ''
+        if ($effectiveAction -eq 'Update') {
+            Write-Host (T 'UpdateSuccess') -ForegroundColor Green
+        } else {
+            Write-Host (T 'InstallSuccess') -ForegroundColor Green
+        }
+        if ($manager.Tag -ne 'local') { Write-Host ("Version: {0}" -f $manager.Tag.TrimStart('v')) }
+        Write-Host (T 'Restart')
+        Write-Host (T 'NextUpdate')
+    } finally {
+        if (Test-Path -LiteralPath $log) {
+            Remove-Item -LiteralPath $log -Force -ErrorAction SilentlyContinue
+        }
+        if ($null -ne $manager.Stage -and (Test-Path -LiteralPath $manager.Stage)) {
+            Remove-Item -LiteralPath $manager.Stage -Recurse -Force -ErrorAction SilentlyContinue
+        }
+    }
+}
+
+try {
+    Invoke-Setup
+} catch {
+    Write-Host ''
+    Write-Host (T 'Failure') -ForegroundColor Red
+    Write-Host $_.Exception.Message
+    Write-Host (T 'Help')
+    exit 1
+}

--- a/dsh-codex.ps1
+++ b/dsh-codex.ps1
@@ -32,8 +32,8 @@ if ($Managed -and -not $PSBoundParameters.ContainsKey('Action')) {
 
 $PackageName = 'dsh-codex-subscription'
 $LegacyPackageName = '@wsl043/dsh-codex-subscription'
-$PackageVersion = '1.0.0'
-$PackageSpec = 'https://github.com/WSL043/dsh-codex-subscription/releases/download/v1.0.0/dsh-codex-subscription.tgz'
+$PackageVersion = '1.0.1'
+$PackageSpec = 'https://github.com/WSL043/dsh-codex-subscription/releases/download/v1.0.1/dsh-codex-subscription.tgz'
 $PnpmVersion = '11.19.0'
 $PnpmUrl = 'https://registry.npmjs.org/pnpm/-/pnpm-11.19.0.tgz'
 $PnpmSha512 = '7881F3ED590D472C4A955E2B88B2121791116066DCC88CBCA3849EC9B60F1BBAA6D2CCB221FA91DA4E1C65BEF2BCBE379365AEA7AC539C7BF86DEDC3A1B22DCE'

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-codex-subscription",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "packageManager": "pnpm@11.19.0",
   "description": "ChatGPT and Codex subscriptions for DeepSeek Harness with OAuth login, image generation, quota, and subscription web search",
   "type": "module",

--- a/tests/powershell-manager.test.mjs
+++ b/tests/powershell-manager.test.mjs
@@ -133,7 +133,7 @@ if (command === 'list') {
   process.stdout.write(JSON.stringify([{ dependencies: packages }]))
 } else if (command === 'add') {
   if (process.env.DSH_CODEX_TEST_FAIL_ADD === '1') process.exit(9)
-  packages['dsh-codex-subscription'] = { version: process.env.DSH_CODEX_TEST_ADDED_VERSION || '1.0.0' }
+  packages['dsh-codex-subscription'] = { version: process.env.DSH_CODEX_TEST_ADDED_VERSION || '1.0.1' }
   fs.writeFileSync(stateFile, JSON.stringify(packages))
 } else if (command === 'remove') {
   delete packages[args[4]]
@@ -214,7 +214,7 @@ windowsTest('update fails instead of reporting success when DSH keeps an older p
       env: { ...process.env, DSH_CODEX_TEST_ADDED_VERSION: '0.2.8' },
     })
     assert.notEqual(result.status, 0)
-    assert.match(result.stderr, /expected 1\.0\.0[^]*found 0\.2\.8/iu)
+    assert.match(result.stderr, /expected 1\.0\.1[^]*found 0\.2\.8/iu)
     assert.doesNotMatch(result.stdout, /Updated\./u)
   } finally {
     rmSync(sandbox, { recursive: true, force: true })
@@ -521,7 +521,7 @@ windowsTest('portable install uses the bundled CLI, DSH_HOME, and package store'
     assert.deepEqual(plan.arguments, [
       join(expectedRoot, 'app', 'node_modules', '@deepseek-ai', 'dsh', 'lib', 'bin.js'),
       'plugin', '--profile', 'web', 'add',
-      'https://github.com/WSL043/dsh-codex-subscription/releases/download/v1.0.0/dsh-codex-subscription.tgz',
+      'https://github.com/WSL043/dsh-codex-subscription/releases/download/v1.0.1/dsh-codex-subscription.tgz',
       '--store-dir', join(expectedRoot, 'data', 'pnpm-store'),
       '--loglevel', 'error',
     ])
@@ -542,7 +542,7 @@ windowsTest('portable install prefers the DSH-Portable command shim when availab
     assert.equal(plan.pnpmDirectory, null)
     assert.deepEqual(plan.arguments, [
       'plugin', '--profile', 'web', 'add',
-      'https://github.com/WSL043/dsh-codex-subscription/releases/download/v1.0.0/dsh-codex-subscription.tgz',
+      'https://github.com/WSL043/dsh-codex-subscription/releases/download/v1.0.1/dsh-codex-subscription.tgz',
       '--store-dir', join(expectedRoot, 'data', 'pnpm-store'),
       '--loglevel', 'error',
     ])
@@ -562,7 +562,7 @@ windowsTest('installed portable mode expands its external state root', () => {
     assert.equal(plan.action, 'Update')
     assert.equal(plan.dshHome, join(realpathSync.native(localAppData), 'DeepSeek-Herness', 'data', 'dsh-home'))
     assert.equal(plan.pnpmStore, join(realpathSync.native(localAppData), 'DeepSeek-Herness', 'data', 'pnpm-store'))
-    assert.equal(plan.arguments.includes('https://github.com/WSL043/dsh-codex-subscription/releases/download/v1.0.0/dsh-codex-subscription.tgz'), true)
+    assert.equal(plan.arguments.includes('https://github.com/WSL043/dsh-codex-subscription/releases/download/v1.0.1/dsh-codex-subscription.tgz'), true)
     assert.equal(plan.packageName, 'dsh-codex-subscription')
     assert.equal(plan.legacyPackageName, '@wsl043/dsh-codex-subscription')
   } finally {

--- a/tests/powershell-setup.test.mjs
+++ b/tests/powershell-setup.test.mjs
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict'
-import { copyFileSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { copyFileSync, mkdirSync, mkdtempSync, readFileSync, realpathSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { spawnSync } from 'node:child_process'
@@ -130,7 +130,9 @@ windowsTest('multiple discovered portable copies become a numbered choice instea
     const plan = parsePlan(result.stdout)
     assert.equal(plan.candidateCount, 2)
     assert.equal(plan.action, 'Install')
-    assert.equal([first, second].includes(plan.target), true)
+    const selected = realpathSync.native(plan.target).toLowerCase()
+    const expected = [first, second].map(root => realpathSync.native(root).toLowerCase())
+    assert.equal(expected.includes(selected), true)
     assert.match(result.stdout, /More than one DSH installation was found/u)
     assert.match(result.stdout, /\[1\][\s\S]*\[2\]/u)
   } finally {

--- a/tests/powershell-setup.test.mjs
+++ b/tests/powershell-setup.test.mjs
@@ -1,0 +1,139 @@
+import assert from 'node:assert/strict'
+import { copyFileSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { spawnSync } from 'node:child_process'
+import test from 'node:test'
+
+const setup = new URL('../dsh-codex-setup.ps1', import.meta.url)
+const windowsTest = process.platform === 'win32' ? test : test.skip
+
+function setupPath() {
+  return setup.pathname.replace(/^\/(?:([A-Za-z]:))/, '$1')
+}
+
+function portableFixture(root, dependencies = null) {
+  for (const directory of [
+    join(root, 'runtime', 'node'),
+    join(root, 'app', 'node_modules', '@deepseek-ai', 'dsh', 'lib'),
+  ]) mkdirSync(directory, { recursive: true })
+
+  copyFileSync(process.execPath, join(root, 'runtime', 'node', 'node.exe'))
+  const serialized = JSON.stringify([{ dependencies: dependencies || {} }])
+  writeFileSync(
+    join(root, 'app', 'node_modules', '@deepseek-ai', 'dsh', 'lib', 'bin.js'),
+    `process.stdout.write(${JSON.stringify(serialized)})\n`,
+  )
+  if (dependencies !== null) mkdirSync(join(root, 'data', 'dsh-home'), { recursive: true })
+}
+
+function runSetup(args, { cwd, env = {}, input } = {}) {
+  return spawnSync('powershell.exe', [
+    '-NoLogo', '-NoProfile', '-ExecutionPolicy', 'Bypass',
+    '-File', setupPath(),
+    ...args,
+  ], {
+    cwd,
+    encoding: 'utf8',
+    env: { ...process.env, ...env },
+    input,
+  })
+}
+
+function parsePlan(stdout) {
+  const match = stdout.match(/(\{[^\r\n]*"language"[^\r\n]*\})\s*$/u)
+  assert.ok(match, `missing dry-run JSON in output:\n${stdout}`)
+  return JSON.parse(match[1])
+}
+
+test('friendly setup is bilingual, checksum-verifies the manager, and avoids code evaluation', () => {
+  const source = readFileSync(setup, 'utf8')
+  assert.equal(source.codePointAt(0), 0xfeff, 'Windows PowerShell 5.1 needs the UTF-8 BOM for Chinese literals')
+  assert.match(source, /1\. 中文（简体）[\s\S]*2\. English/u)
+  assert.match(source, /More than one DSH installation was found/u)
+  assert.match(source, /检测到多个 DSH/u)
+  assert.match(source, /\$effectiveAction = if \(\$isInstalled\) \{ 'Update' \} else \{ 'Install' \}/u)
+  assert.match(source, /dsh-codex\.ps1\.sha256/u)
+  assert.match(source, /Get-FileDigest -Path \$manager/u)
+  assert.doesNotMatch(source, /Invoke-Expression|\biex\b/iu)
+})
+
+windowsTest('fresh portable setup automatically chooses Install', () => {
+  const root = mkdtempSync(join(tmpdir(), 'dsh-codex-friendly-install-'))
+  try {
+    portableFixture(root)
+    const result = runSetup(['-Language', 'en-US', '-PortableRoot', root, '-DryRun'])
+    assert.equal(result.status, 0, result.stderr || result.stdout)
+    const plan = parsePlan(result.stdout)
+    assert.equal(plan.language, 'en-US')
+    assert.equal(plan.candidateCount, 1)
+    assert.equal(plan.mode, 'portable')
+    assert.equal(plan.action, 'Install')
+    assert.equal(plan.installed, false)
+  } finally {
+    rmSync(root, { recursive: true, force: true })
+  }
+})
+
+windowsTest('existing portable setup automatically chooses Update and reports the current version', () => {
+  const root = mkdtempSync(join(tmpdir(), 'dsh-codex-friendly-update-'))
+  try {
+    portableFixture(root, {
+      'dsh-codex-subscription': { version: '0.9.0' },
+      'another-plugin': { version: '1.2.3' },
+    })
+    const result = runSetup(['-Language', 'zh-CN', '-PortableRoot', root, '-DryRun'])
+    assert.equal(result.status, 0, result.stderr || result.stdout)
+    const plan = parsePlan(result.stdout)
+    assert.equal(plan.language, 'zh-CN')
+    assert.equal(plan.action, 'Update')
+    assert.equal(plan.installed, true)
+    assert.equal(plan.installedVersion, '0.9.0')
+    assert.match(result.stdout, /操作:\s*更新/u)
+  } finally {
+    rmSync(root, { recursive: true, force: true })
+  }
+})
+
+windowsTest('language is the first interactive choice when it is not supplied', () => {
+  const root = mkdtempSync(join(tmpdir(), 'dsh-codex-friendly-language-'))
+  try {
+    portableFixture(root)
+    const result = runSetup(['-PortableRoot', root, '-DryRun'], { input: '2\r\n' })
+    assert.equal(result.status, 0, result.stderr || result.stdout)
+    const plan = parsePlan(result.stdout)
+    assert.equal(plan.language, 'en-US')
+    assert.match(result.stdout, /1\. 中文（简体）/u)
+    assert.match(result.stdout, /2\. English/u)
+  } finally {
+    rmSync(root, { recursive: true, force: true })
+  }
+})
+
+windowsTest('multiple discovered portable copies become a numbered choice instead of an exception', () => {
+  const sandbox = mkdtempSync(join(tmpdir(), 'dsh-codex-friendly-multiple-'))
+  const first = join(sandbox, 'Downloads', 'Alpha DSH')
+  const second = join(sandbox, 'Downloads', 'Beta DSH')
+  try {
+    portableFixture(first)
+    portableFixture(second)
+    mkdirSync(join(sandbox, 'LocalAppData'), { recursive: true })
+    const result = runSetup(['-Language', 'en-US', '-DryRun'], {
+      cwd: sandbox,
+      env: {
+        USERPROFILE: sandbox,
+        LOCALAPPDATA: join(sandbox, 'LocalAppData'),
+      },
+      input: '1\r\n',
+    })
+    assert.equal(result.status, 0, result.stderr || result.stdout)
+    const plan = parsePlan(result.stdout)
+    assert.equal(plan.candidateCount, 2)
+    assert.equal(plan.action, 'Install')
+    assert.equal([first, second].includes(plan.target), true)
+    assert.match(result.stdout, /More than one DSH installation was found/u)
+    assert.match(result.stdout, /\[1\][\s\S]*\[2\]/u)
+  } finally {
+    rmSync(sandbox, { recursive: true, force: true })
+  }
+})

--- a/tests/release-contract.test.mjs
+++ b/tests/release-contract.test.mjs
@@ -20,7 +20,7 @@ test('release is a prebuilt, documented, removable DSH bundle', () => {
     'docs/assets/*.png',
   ]) assert.equal(included.has(path), true, `package files must include ${path}`)
   assert.equal(pkg.name, 'dsh-codex-subscription')
-  assert.equal(pkg.version, '1.0.0')
+  assert.equal(pkg.version, '1.0.1')
   assert.equal(pkg.homepage, 'https://github.com/WSL043/dsh-codex-subscription')
   assert.equal('prepare' in pkg.scripts, false, 'GitHub installs use committed build output')
   assert.equal(pkg.dependencies?.['@earendil-works/pi-ai'], undefined)
@@ -39,6 +39,7 @@ test('release is a prebuilt, documented, removable DSH bundle', () => {
   assert.equal(existsSync(new URL('../CHANGELOG.md', import.meta.url)), false)
   assert.equal(existsSync(new URL('../docs/ARCHITECTURE.md', import.meta.url)), false)
   assert.equal(existsSync(new URL('../.github/workflows/ci.yml', import.meta.url)), true)
+  assert.equal(existsSync(new URL('../.github/workflows/release.yml', import.meta.url)), true)
 })
 
 test('public docs contain only user-facing product and operation information', () => {
@@ -55,12 +56,12 @@ test('public docs contain only user-facing product and operation information', (
 
 test('shipped agent guide owns install, pinned update, verification, and uninstall', () => {
   const guide = text('AGENTS.md')
-  assert.match(guide, /releases\/download\/v1\.0\.0\/dsh-codex\.ps1/u)
+  assert.match(guide, /releases\/download\/v1\.0\.1\/dsh-codex\.ps1/u)
   assert.match(guide, /dsh-codex\.ps1" Install/u)
   assert.match(guide, /dsh-codex update/u)
   assert.match(guide, /dsh-codex uninstall/u)
   assert.match(guide, /DSH-Portable[\s\S]*system Node\.js or pnpm[\s\S]*per-user[\s\S]*never modifies[\s\S]*machine PATH/iu)
-  assert.match(guide, /dsh plugin --profile web add dsh-codex-subscription@1\.0\.0/u)
+  assert.match(guide, /dsh plugin --profile web add dsh-codex-subscription@1\.0\.1/u)
   assert.match(guide, /dsh plugin --profile web update dsh-codex-subscription/u)
   assert.match(guide, /dsh plugin --profile web list dsh-codex-subscription --depth 0/u)
   assert.match(guide, /dsh --profile web --dump-config/u)
@@ -85,10 +86,12 @@ test('GitHub defaults to concise Chinese and directs Agents to their own guide',
   assert.match(readmeEn, /## Prepare DSH[\s\S]*community DSH-Portable package[\s\S]*github\.com\/deepseek-ai\/deepseek-harness#run[\s\S]*## Install[\s\S]*### Let an Agent install it \(recommended\)[\s\S]*https:\/\/raw\.githubusercontent\.com\/WSL043\/dsh-codex-subscription\/main\/AGENTS\.md[\s\S]*### Manual Windows install/u)
   assert.match(readme, /本项目的问题反馈[\s\S]*github\.com\/WSL043\/dsh-codex-subscription\/issues[\s\S]*github\.com\/deepseek-ai\/deepseek-harness\/discussions/u)
   assert.match(readmeEn, /project feedback[\s\S]*github\.com\/deepseek-ai\/deepseek-harness\/discussions/u)
-  assert.match(readme, /依次粘贴下面两行/u)
-  assert.match(readmeEn, /paste these two lines in order/u)
-  assert.doesNotMatch(`${readme}\n${readmeEn}`, /下面三行|three lines/iu)
-  assert.doesNotMatch(readme, /复制下面|提示词/u)
+  assert.match(readme, /只需要复制这一行/u)
+  assert.match(readmeEn, /paste this one line/u)
+  assert.doesNotMatch(`${readme}\n${readmeEn}`, /依次粘贴下面两行|paste these two lines in order|下面三行|three lines/iu)
+  assert.match(readme, /releases\/latest\/download\/dsh-codex-setup\.ps1/u)
+  assert.match(readmeEn, /releases\/latest\/download\/dsh-codex-setup\.ps1/u)
+  assert.doesNotMatch(readme, /提示词/u)
   assert.match(readme, /https:\/\/raw\.githubusercontent\.com\/WSL043\/dsh-codex-subscription\/main\/docs\/assets\/settings\.png/u)
   assert.match(readmeEn, /https:\/\/raw\.githubusercontent\.com\/WSL043\/dsh-codex-subscription\/main\/docs\/assets\/settings-en\.png/u)
   assert.match(readme, /raw\.githubusercontent\.com\/WSL043\/dsh-codex-subscription\/main\/docs\/assets\/composer-quota-en\.png/u)
@@ -128,6 +131,7 @@ test('public readmes provide explicit update commands and verification', () => {
   assert.match(readmeZh, /dsh plugin --profile web add dsh-codex-subscription/u)
   assert.match(readmeEn, /dsh plugin --profile web add dsh-codex-subscription/u)
   for (const readme of [readmeZh, readmeEn]) {
+    assert.match(readme, /releases\/latest\/download\/dsh-codex-setup\.ps1/u)
     assert.match(readme, /releases\/latest\/download\/dsh-codex\.ps1/u)
     assert.doesNotMatch(readme, /dsh-codex\.ps1\?/u)
     assert.match(readme, /curl\.exe -fL[\s\S]*-o "\$env:TEMP\\dsh-codex\.ps1"[\s\S]*-ExecutionPolicy Bypass -File/iu)
@@ -138,6 +142,8 @@ test('public readmes provide explicit update commands and verification', () => {
 
 test('Windows manager updates from a checksum-verified immutable release asset', () => {
   const manager = text('dsh-codex.ps1')
+  assert.match(manager, /\$PackageVersion = '1\.0\.1'/u)
+  assert.match(manager, /releases\/download\/v1\.0\.1\/dsh-codex-subscription\.tgz/u)
   assert.match(manager, /api\.github\.com\/repos\/WSL043\/dsh-codex-subscription\/releases\/latest/u)
   assert.match(manager, /dsh-codex\.ps1\.sha256/u)
   assert.match(manager, /Get-FileDigest -Algorithm SHA256/u)
@@ -199,6 +205,19 @@ test('CI uploads the hidden release artifact only after asserting it exists', ()
   assert.match(workflow, /include-hidden-files:\s*true/u)
   assert.match(workflow, /sha256sum dsh-codex\.ps1/u)
   assert.match(workflow, /\.artifacts\/dsh-codex\.ps1\.sha256/u)
+  assert.match(workflow, /\.artifacts\/dsh-codex-setup\.ps1/u)
+})
+
+test('successful main CI creates one immutable GitHub release for the package version', () => {
+  const workflow = text('.github/workflows/release.yml')
+  assert.match(workflow, /workflow_run:[\s\S]*workflows:\s*\[CI\][\s\S]*types:\s*\[completed\]/u)
+  assert.match(workflow, /workflow_run\.conclusion == 'success'/u)
+  assert.match(workflow, /workflow_run\.head_branch == 'main'/u)
+  assert.match(workflow, /contents:\s*write/u)
+  assert.match(workflow, /gh release view/u)
+  assert.match(workflow, /gh release create/u)
+  assert.match(workflow, /dsh-codex-subscription\.tgz/u)
+  assert.match(workflow, /dsh-codex-setup\.ps1/u)
 })
 
 test('npm publishing is release-gated and uses OIDC without a stored npm token', () => {
@@ -212,6 +231,7 @@ test('npm publishing is release-gated and uses OIDC without a stored npm token',
     'dsh-codex-subscription.tgz',
     'dsh-codex.ps1',
     'dsh-codex.ps1.sha256',
+    'dsh-codex-setup.ps1',
   ]) assert.match(workflow, new RegExp(asset.replaceAll('.', '\\.')))
   for (const asset of [
     'settings.png',


### PR DESCRIPTION
## What changed

- add `dsh-codex-setup.ps1` as the beginner-friendly Windows entry point
- ask for 简体中文 / English before doing anything else
- turn multiple DSH installations into a numbered target picker instead of a PowerShell exception
- auto-detect Install vs Update, including legacy-package migration
- keep `dsh-codex.ps1` as the non-interactive core for Agents and automation
- keep the core manager SHA-256 verification path intact
- make the public Windows install a single PowerShell line without `irm | iex`
- bump the package/manager/Agent pinned release to `v1.0.1`
- add Windows tests for language selection, fresh install, update detection, and multi-install selection
- add a main-only release workflow: successful `main` CI creates the immutable GitHub Release assets
- require `dsh-codex-setup.ps1` in the npm publish release gate

## Release behavior

After this is merged, the normal `main` CI runs first. If it succeeds, the Release workflow creates `v1.0.1` with:

- `dsh-codex-subscription.tgz`
- `dsh-codex.ps1`
- `dsh-codex.ps1.sha256`
- `dsh-codex-setup.ps1`

Publishing that Release then triggers the existing OIDC npm publish workflow.

## Safety / compatibility

The friendly setup only selects language, target, and Install/Update intent; the existing manager still owns package installation, migration, verification, PATH handling, profile preservation, credential preservation, and the no-auto-restart behavior.