### PR TITLE
fix: provide request image budgets

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1055,6 +1055,9 @@ const LEGACY_CREDENTIAL_REF = credentialRef("WSL043_OPENAI_CODEX_OAUTH");
 const CHANNEL = "/codex-subscription";
 const WEB_ENTRY_ID = "web";
 const DSH_SEARCH_PROVIDER_FALLBACK = "deepseek-official";
+const MAX_REQUEST_IMAGE_BYTES = 20 * 1024 * 1024;
+const REQUEST_IMAGE_PIXEL_BUDGET = 2048 * 2048;
+const REQUEST_IMAGE_MAX_BYTES = 1024 * 1024;
 const publicError = (code, message) => ({
 	ok: false,
 	error: {
@@ -1165,6 +1168,9 @@ function apply(ctx) {
 		piProvider: provider,
 		configuredMaxTokens: /* @__PURE__ */ new Map(),
 		streamIdleTimeoutMs: 600 * 1e3,
+		maxRequestImageBytes: MAX_REQUEST_IMAGE_BYTES,
+		requestImagePixelBudget: REQUEST_IMAGE_PIXEL_BUDGET,
+		requestImageMaxBytes: REQUEST_IMAGE_MAX_BYTES,
 		cacheRetention: "short",
 		transport: "sse"
 	});

--- a/src/index.js
+++ b/src/index.js
@@ -38,6 +38,9 @@ const LEGACY_CREDENTIAL_REF = credentialRef('WSL043_OPENAI_CODEX_OAUTH')
 const CHANNEL = '/codex-subscription'
 const WEB_ENTRY_ID = 'web'
 const DSH_SEARCH_PROVIDER_FALLBACK = 'deepseek-official'
+const MAX_REQUEST_IMAGE_BYTES = 20 * 1024 * 1024
+const REQUEST_IMAGE_PIXEL_BUDGET = 2048 * 2048
+const REQUEST_IMAGE_MAX_BYTES = 1024 * 1024
 
 const publicError = (code, message) => ({
   ok: false,
@@ -161,6 +164,11 @@ export function apply(ctx) {
     piProvider: provider,
     configuredMaxTokens: new Map(),
     streamIdleTimeoutMs: 10 * 60 * 1000,
+    // Custom PiAiAdapter profiles bypass the settings-backed profile resolver,
+    // so request-image limits must be complete here rather than left undefined.
+    maxRequestImageBytes: MAX_REQUEST_IMAGE_BYTES,
+    requestImagePixelBudget: REQUEST_IMAGE_PIXEL_BUDGET,
+    requestImageMaxBytes: REQUEST_IMAGE_MAX_BYTES,
     // pi-ai owns prompt_cache_key and encrypted reasoning replay. The explicit
     // profile values make the subscription cache contract auditable.
     cacheRetention: 'short',

--- a/tests/plugin-integration.test.mjs
+++ b/tests/plugin-integration.test.mjs
@@ -116,6 +116,16 @@ test('plugin registers one Codex route, subscription image tool, and loopback-on
 
   assert.equal('CODEX_PROVIDER_POLICY' in plugin, false, 'do not replace the removed boundary with cosmetic metadata')
   assert.deepEqual(host.registered.map(item => item.providers), [['openai-codex']])
+  const profile = host.registered[0].adapter.current().profiles.get('openai-codex')
+  assert.deepEqual({
+    maxRequestImageBytes: profile.maxRequestImageBytes,
+    requestImagePixelBudget: profile.requestImagePixelBudget,
+    requestImageMaxBytes: profile.requestImageMaxBytes,
+  }, {
+    maxRequestImageBytes: 20 * 1024 * 1024,
+    requestImagePixelBudget: 2048 * 2048,
+    requestImageMaxBytes: 1024 * 1024,
+  })
   assert.deepEqual(host.searchProviders.map(provider => provider.id), ['codex-subscription'])
   assert.deepEqual(host.tools.map(tool => tool.name), ['codex_image_generate'])
   assert.equal(host.registered[0].adapter.providerRetryPolicy(), undefined)


### PR DESCRIPTION
## Summary

- provide the complete request-image limits expected by custom `PiAiAdapter` profiles
- keep the values aligned with the DSH pi-ai defaults
- add integration coverage for the registered Codex profile

## Problem

After a durable image (for example, a Unity screenshot returned by a tool) enters the conversation, the next Codex model request fails before reaching the provider:

```text
Image request maxPixels must be a positive integer.
```

The subscription plugin constructs a custom profile directly and therefore bypasses the settings-backed profile resolver that normally supplies defaults. `requestImagePixelBudget`, `requestImageMaxBytes`, and `maxRequestImageBytes` were left undefined.

## Validation

- `pnpm run check`
- 124 tests: 88 passed, 36 platform-specific tests skipped
- host and client bundles built successfully
- npm package assembled successfully



Closes #9
