### PR TITLE
Fix preview compatibility automation

### DIFF
--- a/scripts/prepare-compat-release.mjs
+++ b/scripts/prepare-compat-release.mjs
@@ -129,6 +129,24 @@ export function rewriteBoundedVersions(source, update, label) {
   return rewritten
 }
 
+export function boundedArtifactPaths(update) {
+  if (!update.updateStableReferences) return []
+  return [
+    'README.md',
+    'README.en.md',
+    'AGENTS.md',
+    'dsh-codex.ps1',
+    '.github/scripts/accept-official-release.ps1',
+  ]
+}
+
+export function rewriteWorkspaceCohort(workspace, update) {
+  if (!update.updateStableReferences) return workspace
+  const rewritten = workspace.replaceAll(update.previousDshVersion, update.dshVersion)
+  if (rewritten === workspace) throw new Error(`DSH release cohort ${update.previousDshVersion} was not found`)
+  return rewritten
+}
+
 export function extractDeepSeekReleaseAgeSelectors(lockfile) {
   const packagesStart = lockfile.indexOf('\npackages:\n')
   const snapshotsStart = lockfile.indexOf('\nsnapshots:\n')
@@ -164,21 +182,13 @@ async function prepare(root, candidate) {
   const update = planCompatibilityUpdate({ compatibility, manifest }, candidate)
   if (update === null) return { changed: false, dshVersion: candidate, pluginVersion: manifest.version }
 
-  const boundedPaths = [
-    'README.md',
-    'README.en.md',
-    'AGENTS.md',
-    'dsh-codex.ps1',
-    '.github/scripts/accept-official-release.ps1',
-  ]
+  const boundedPaths = boundedArtifactPaths(update)
   const sources = await Promise.all(boundedPaths.map(path => readFile(resolve(root, path), 'utf8')))
   const rewritten = sources.map((source, index) => rewriteBoundedVersions(source, update, boundedPaths[index]))
 
   const workspacePath = resolve(root, 'pnpm-workspace.yaml')
   const workspace = await readFile(workspacePath, 'utf8')
-  const nextWorkspace = workspace
-    .replaceAll(update.previousDshVersion, update.dshVersion)
-  if (nextWorkspace === workspace) throw new Error(`DSH release cohort ${update.previousDshVersion} was not found`)
+  const nextWorkspace = rewriteWorkspaceCohort(workspace, update)
 
   await Promise.all([
     writeFile(compatibilityPath, `${JSON.stringify(update.compatibility, null, 2)}\n`),

--- a/tests/prepare-compat-release.test.mjs
+++ b/tests/prepare-compat-release.test.mjs
@@ -2,11 +2,13 @@ import assert from 'node:assert/strict'
 import test from 'node:test'
 
 import {
+  boundedArtifactPaths,
   compareVersions,
   extractDeepSeekReleaseAgeSelectors,
   planCompatibilityUpdate,
   rewriteBoundedVersions,
   rewriteReleaseAgeCohort,
+  rewriteWorkspaceCohort,
   selectNextUntestedVersion,
 } from '../scripts/prepare-compat-release.mjs'
 
@@ -71,6 +73,8 @@ test('plans preview DSH support as a plugin beta without moving the stable lane'
     update.manifest.peerDependencies['@deepseek-ai/dsh-web'],
     '0.1.1-rc.2 || 0.1.2-alpha.1 || 0.1.2-alpha.2 || 0.1.2-alpha.3',
   )
+  assert.deepEqual(boundedArtifactPaths(update), [])
+  assert.equal(rewriteWorkspaceCohort('stable release-age policy', update), 'stable release-age policy')
 })
 
 test('increments repeated plugin betas and promotes the same patch when DSH leaves preview', () => {
@@ -91,6 +95,17 @@ test('plans one stable plugin patch for one newly accepted DSH version', () => {
   )
   assert.equal(update.manifest.devDependencies.react, '18.3.1')
   assert.equal(update.manifest.peerDependencies.react, '^18.2.0')
+  assert.deepEqual(boundedArtifactPaths(update), [
+    'README.md',
+    'README.en.md',
+    'AGENTS.md',
+    'dsh-codex.ps1',
+    '.github/scripts/accept-official-release.ps1',
+  ])
+  assert.equal(
+    rewriteWorkspaceCohort('cohort 0.1.0-rc.8', update),
+    'cohort 0.1.1-rc.1',
+  )
 })
 
 test('is idempotent for an accepted version and refuses rollback', () => {


### PR DESCRIPTION
Keeps Alpha compatibility updates in the preview dependency lane instead of requiring stable README and installer rewrites. Adds regression coverage for preview and stable artifact selection and workspace cohort handling.\n\nThis unblocks official DSH 0.1.2-alpha.4 acceptance.