### PR TITLE
Keep preview-only peers optional

### DIFF
--- a/scripts/prepare-compat-release.mjs
+++ b/scripts/prepare-compat-release.mjs
@@ -102,8 +102,10 @@ export function planCompatibilityUpdate(state, candidate) {
   const manifest = structuredClone(state.manifest)
   const previousPluginVersion = manifest.version
   manifest.version = preview ? nextBetaVersion(previousPluginVersion) : nextStableVersion(previousPluginVersion)
-  for (const name of Object.keys(manifest.devDependencies ?? {})) {
-    if (name.startsWith('@deepseek-ai/dsh-')) manifest.devDependencies[name] = candidate
+  if (!preview) {
+    for (const name of Object.keys(manifest.devDependencies ?? {})) {
+      if (name.startsWith('@deepseek-ai/dsh-')) manifest.devDependencies[name] = candidate
+    }
   }
   const supportedRange = [...compatibility.supported, ...compatibility.previews].sort(compareVersions).join(' || ')
   for (const name of Object.keys(manifest.peerDependencies ?? {})) {

--- a/tests/prepare-compat-release.test.mjs
+++ b/tests/prepare-compat-release.test.mjs
@@ -68,7 +68,7 @@ test('plans preview DSH support as a plugin beta without moving the stable lane'
   assert.equal(update.compatibility.latestTested, '0.1.1-rc.2')
   assert.deepEqual(update.compatibility.supported, ['0.1.1-rc.2'])
   assert.deepEqual(update.compatibility.previews, ['0.1.2-alpha.1', '0.1.2-alpha.2', '0.1.2-alpha.3'])
-  assert.equal(update.manifest.devDependencies['@deepseek-ai/dsh-web'], '0.1.2-alpha.3')
+  assert.equal(update.manifest.devDependencies['@deepseek-ai/dsh-web'], '0.1.2-alpha.2')
   assert.equal(
     update.manifest.peerDependencies['@deepseek-ai/dsh-web'],
     '0.1.1-rc.2 || 0.1.2-alpha.1 || 0.1.2-alpha.2 || 0.1.2-alpha.3',


### PR DESCRIPTION
Official DSH Alpha can publish the host entry without publishing every optional peer at the same version. Keep stable development dependencies for preview acceptance while extending the optional peer range; the official Alpha host remains the end-to-end compatibility authority. This unblocks 0.1.2-alpha.4.