### PR TITLE
Test preview candidates without moving stable manager

### DIFF
--- a/tests/powershell-manager.test.mjs
+++ b/tests/powershell-manager.test.mjs
@@ -9,7 +9,9 @@ import { createServer } from 'node:http'
 import test from 'node:test'
 
 const script = new URL('../dsh-codex.ps1', import.meta.url)
-const manifestVersion = JSON.parse(readFileSync(new URL('../package.json', import.meta.url), 'utf8')).version
+const managerSource = readFileSync(script, 'utf8')
+const managedVersion = managerSource.match(/\$PackageVersion = '(\d+\.\d+\.\d+)'/u)?.[1]
+assert.match(managedVersion ?? '', /^\d+\.\d+\.\d+$/u)
 const windowsTest = process.platform === 'win32' ? test : test.skip
 const userPathTest = process.platform === 'win32' && process.env.DSH_CODEX_TEST_USER_PATH === '1'
   ? test
@@ -143,7 +145,7 @@ if (command === 'list') {
     process.exit(1)
   }
   if (process.env.DSH_CODEX_TEST_FAIL_ADD === '1') process.exit(9)
-  packages['dsh-codex-subscription'] = { version: process.env.DSH_CODEX_TEST_ADDED_VERSION || '${manifestVersion}' }
+  packages['dsh-codex-subscription'] = { version: process.env.DSH_CODEX_TEST_ADDED_VERSION || '${managedVersion}' }
   fs.writeFileSync(stateFile, JSON.stringify(packages))
 } else if (command === 'remove') {
   delete packages[args[4]]
@@ -175,7 +177,7 @@ windowsTest('legacy manager can install into a completely new profile with an em
     })
     assert.equal(result.status, 0, result.stderr || result.stdout)
     const installed = JSON.parse(readFileSync(join(root, 'data', 'dsh-home', 'fake-packages.json'), 'utf8'))
-    assert.equal(installed['dsh-codex-subscription'].version, manifestVersion)
+    assert.equal(installed['dsh-codex-subscription'].version, managedVersion)
   } finally {
     rmSync(sandbox, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 })
   }
@@ -273,7 +275,7 @@ windowsTest('update fails instead of reporting success when DSH keeps an older p
       env: { ...process.env, DSH_CODEX_TEST_ADDED_VERSION: '0.2.8' },
     })
     assert.notEqual(result.status, 0)
-    assert.match(result.stderr, new RegExp(`expected ${manifestVersion.replaceAll('.', '\\.')}[^]*found 0\\.2\\.8`, 'iu'))
+    assert.match(result.stderr, new RegExp(`expected ${managedVersion.replaceAll('.', '\\.')}[^]*found 0\\.2\\.8`, 'iu'))
     assert.doesNotMatch(result.stdout, /Updated\./u)
   } finally {
     rmSync(sandbox, { recursive: true, force: true })
@@ -737,7 +739,7 @@ windowsTest('portable install uses the bundled CLI, DSH_HOME, and package store'
     assert.deepEqual(plan.arguments, [
       join(expectedRoot, 'app', 'node_modules', '@deepseek-ai', 'dsh', 'lib', 'bin.js'),
       'plugin', '--profile', 'web', 'add',
-      `dsh-codex-subscription@${manifestVersion}`,
+      `dsh-codex-subscription@${managedVersion}`,
       '--store-dir', join(expectedRoot, 'data', 'pnpm-store'),
       '--loglevel', 'error',
     ])
@@ -758,7 +760,7 @@ windowsTest('portable install prefers the DSH-Portable command shim when availab
     assert.equal(plan.pnpmDirectory, null)
     assert.deepEqual(plan.arguments, [
       'plugin', '--profile', 'web', 'add',
-      `dsh-codex-subscription@${manifestVersion}`,
+      `dsh-codex-subscription@${managedVersion}`,
       '--store-dir', join(expectedRoot, 'data', 'pnpm-store'),
       '--loglevel', 'error',
     ])
@@ -778,7 +780,7 @@ windowsTest('installed portable mode expands its external state root', () => {
     assert.equal(plan.action, 'Update')
     assert.equal(plan.dshHome, join(realpathSync.native(localAppData), 'DeepSeek-Herness', 'data', 'dsh-home'))
     assert.equal(plan.pnpmStore, join(realpathSync.native(localAppData), 'DeepSeek-Herness', 'data', 'pnpm-store'))
-    assert.equal(plan.arguments.includes(`dsh-codex-subscription@${manifestVersion}`), true)
+    assert.equal(plan.arguments.includes(`dsh-codex-subscription@${managedVersion}`), true)
     assert.equal(plan.packageName, 'dsh-codex-subscription')
     assert.equal(plan.legacyPackageName, '@wsl043/dsh-codex-subscription')
   } finally {

--- a/tests/release-contract.test.mjs
+++ b/tests/release-contract.test.mjs
@@ -75,7 +75,9 @@ test('settings registration works across stable and preview DSH exports', () => 
 
 test('compatibility metadata keeps stable and preview DSH lanes explicit', () => {
   assert.equal(compatibility.latestTested, '0.1.1-rc.2')
-  assert.deepEqual(compatibility.previews, ['0.1.2-alpha.2', '0.1.2-alpha.3'])
+  assert.deepEqual(compatibility.previews.slice(0, 2), ['0.1.2-alpha.2', '0.1.2-alpha.3'])
+  assert.equal(new Set(compatibility.previews).size, compatibility.previews.length)
+  assert.ok(compatibility.previews.every(version => /^\d+\.\d+\.\d+-[0-9A-Za-z.-]+$/u.test(version)))
 })
 
 test('public docs contain only user-facing product and operation information', () => {
@@ -94,9 +96,11 @@ test('public docs contain only user-facing product and operation information', (
 
 test('shipped agent guide owns install, pinned update, verification, and uninstall', () => {
   const guide = text('AGENTS.md')
-  assert.equal(guide.includes(`dsh plugin --profile web add dsh-codex-subscription@${manifest.version}`), true)
+  const documentedVersion = guide.match(/dsh plugin --profile web add dsh-codex-subscription@(\d+\.\d+\.\d+)/u)?.[1]
+  assert.match(documentedVersion ?? '', /^\d+\.\d+\.\d+$/u)
+  assert.doesNotMatch(guide, /dsh-codex-subscription@\d+\.\d+\.\d+-beta\.\d+/u)
   assert.doesNotMatch(guide, /\\dsh\.exe plugin/iu)
-  assert.equal(guide.includes(`npx -y @deepseek-ai/dsh@${compatibility.latestTested} plugin --profile web add dsh-codex-subscription@${manifest.version}`), true)
+  assert.equal(guide.includes(`npx -y @deepseek-ai/dsh@${compatibility.latestTested} plugin --profile web add dsh-codex-subscription@${documentedVersion}`), true)
   assert.match(guide, /dsh plugin --profile web list dsh-codex-subscription --depth 0/u)
   assert.match(guide, /dsh --profile web --dump-config/u)
   assert.match(guide, /dsh plugin --profile web remove dsh-codex-subscription/u)
@@ -200,8 +204,10 @@ test('public readmes provide explicit update commands and verification', () => {
 
 test('Windows manager updates from a checksum-verified immutable release asset', () => {
   const manager = text('dsh-codex.ps1')
-  assert.equal(manager.includes(`$PackageVersion = '${manifest.version}'`), true)
-  assert.equal(manager.includes(`$PackageSpec = 'dsh-codex-subscription@${manifest.version}'`), true)
+  const managedVersion = manager.match(/\$PackageVersion = '(\d+\.\d+\.\d+)'/u)?.[1]
+  assert.match(managedVersion ?? '', /^\d+\.\d+\.\d+$/u)
+  assert.equal(manager.includes(`$PackageSpec = 'dsh-codex-subscription@${managedVersion}'`), true)
+  assert.doesNotMatch(manager, /dsh-codex-subscription@\d+\.\d+\.\d+-beta\.\d+/u)
   assert.match(manager, /api\.github\.com\/repos\/WSL043\/dsh-codex-subscription\/releases\/latest/u)
   assert.match(manager, /dsh-codex\.ps1\.sha256/u)
   assert.match(manager, /Get-FileDigest -Algorithm SHA256/u)


### PR DESCRIPTION
Validate prerelease candidate metadata separately from the stable public installer and Windows manager. Verified against the generated DSH 0.1.2-alpha.4 candidate: 207 tests pass and 3 real-user-PATH tests remain intentionally skipped.