### PR TITLE
Tolerate delayed Windows temporary cleanup

### DIFF
--- a/tests/powershell-manager.test.mjs
+++ b/tests/powershell-manager.test.mjs
@@ -580,7 +580,7 @@ windowsTest('direct uninstall removes only manager-owned files from a custom com
     assert.equal(existsSync(join(commandRoot, 'dsh-codex.ps1')), false)
     assert.equal(existsSync(join(commandRoot, 'dsh-codex.cmd')), false)
   } finally {
-    rmSync(sandbox, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 })
+    rmSync(sandbox, { recursive: true, force: true, maxRetries: 20, retryDelay: 250 })
   }
 })
 


### PR DESCRIPTION
Allow the bounded uninstall test more time to remove its own temporary sandbox after Windows PowerShell exits. The product assertions already passed; the prior Windows 2022 failure was an EPERM during finally cleanup. Local Windows verification: 25 passed, 3 real-user-PATH tests skipped by design.