### PR TITLE
fix: carry model diagnostics on the custom adapter profile

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -3882,6 +3882,7 @@ function apply(ctx) {
 		displayName: "ChatGPT subscription",
 		piProvider: provider,
 		configuredMaxTokens: /* @__PURE__ */ new Map(),
+		modelErrors: /* @__PURE__ */ new Map(),
 		streamIdleTimeoutMs: 600 * 1e3,
 		maxRequestImageBytes: MAX_REQUEST_IMAGE_BYTES,
 		requestImagePixelBudget: REQUEST_IMAGE_PIXEL_BUDGET,

--- a/src/index.js
+++ b/src/index.js
@@ -160,6 +160,10 @@ export function apply(ctx) {
     displayName: 'ChatGPT subscription',
     piProvider: provider,
     configuredMaxTokens: new Map(),
+    // Custom PiAiAdapter profiles bypass the settings-backed profile resolver,
+    // so the model diagnostics the host adapter reads on resolution must be
+    // present here rather than left undefined.
+    modelErrors: new Map(),
     streamIdleTimeoutMs: 10 * 60 * 1000,
     // Custom PiAiAdapter profiles bypass the settings-backed profile resolver,
     // so request-image limits must be complete here rather than left undefined.

--- a/tests/model-catalog.test.mjs
+++ b/tests/model-catalog.test.mjs
@@ -70,7 +70,7 @@ test('Astra from the official catalog reaches DSH with the selected context wind
   const adapter = new PiAiAdapter({
     profiles: () => new Map([['openai-codex', {
       provider: 'openai-codex', displayName: 'ChatGPT subscription',
-      piProvider: provider, configuredMaxTokens: new Map(),
+      piProvider: provider, configuredMaxTokens: new Map(), modelErrors: new Map(),
     }]]),
     resolveApiKey: async () => { throw new Error('context resolution must not send a model request') },
   })

--- a/tests/plugin-integration.test.mjs
+++ b/tests/plugin-integration.test.mjs
@@ -207,6 +207,25 @@ test('plugin activates without the web connection service in Headless mode', () 
   assert.equal(host.handled.length, 0)
 })
 
+test('every advertised Codex model resolves and prepares without reading credentials', async () => {
+  const host = fakeContext()
+  applyPlugin(host.ctx)
+  // Activation may inspect account state; model metadata must not require it.
+  host.ctx.credentials.resolve = async () => assert.fail('model metadata must not read credentials')
+  const adapter = host.registered[0].adapter
+  const models = await adapter.listModels('openai-codex')
+  assert.ok(models.length > 0)
+  for (const model of models) {
+    const resolved = await adapter.resolveModel('openai-codex', model.id)
+    assert.equal(resolved.provider, 'openai-codex')
+    assert.equal(resolved.id, model.id)
+    assert.ok(resolved.context.contextWindow > 0)
+    const prepared = await adapter.prepareCall('openai-codex', model.id)
+    assert.deepEqual(prepared.model, resolved)
+    assert.equal(typeof prepared.stream, 'function')
+  }
+})
+
 test('plugin registers one Codex route, subscription image tool, and DSH-trusted redacted RPC', async () => {
   const host = fakeContext()
   applyPlugin(host.ctx)

--- a/tests/plugin-integration.test.mjs
+++ b/tests/plugin-integration.test.mjs
@@ -223,6 +223,8 @@ test('plugin registers one Codex route, subscription image tool, and DSH-trusted
     requestImagePixelBudget: 2048 * 2048,
     requestImageMaxBytes: 1024 * 1024,
   })
+  assert.ok(profile.modelErrors instanceof Map, 'the host adapter reads model diagnostics from the profile on resolution')
+  assert.equal(profile.modelErrors.get('gpt-5.5'), undefined, 'a serviceable model records no diagnostic')
   assert.deepEqual(host.searchProviders.map(provider => provider.id), ['codex-subscription', 'codex-subscription-auto'])
   assert.deepEqual(host.tools.map(tool => tool.name), ['codex_image_generate'])
   assert.equal(host.registered[0].adapter.providerRetryPolicy(), undefined)

--- a/tests/transport-contract.test.mjs
+++ b/tests/transport-contract.test.mjs
@@ -105,7 +105,7 @@ test('DSH PiAiAdapter can execute the OAuth-only Codex provider with a refreshed
       provider: 'openai-codex',
       displayName: 'ChatGPT subscription',
       piProvider: provider,
-      configuredMaxTokens: new Map(),
+      configuredMaxTokens: new Map(), modelErrors: new Map(),
       transport: 'sse',
       streamIdleTimeoutMs: 10_000,
     }]])
@@ -188,7 +188,7 @@ test('a near-expiry OAuth token refreshes before the first model request is disp
       provider: 'openai-codex',
       displayName: 'ChatGPT subscription',
       piProvider: requestProvider,
-      configuredMaxTokens: new Map(),
+      configuredMaxTokens: new Map(), modelErrors: new Map(),
       transport: 'sse',
       streamIdleTimeoutMs: 10_000,
     }]])
@@ -231,7 +231,7 @@ test('subscription fast mode reaches only officially supported Codex model reque
       provider: 'openai-codex',
       displayName: 'ChatGPT subscription',
       piProvider: provider,
-      configuredMaxTokens: new Map(),
+      configuredMaxTokens: new Map(), modelErrors: new Map(),
       transport: 'sse',
       streamIdleTimeoutMs: 10_000,
     }]])
@@ -283,7 +283,7 @@ test('output detail reaches only verbosity-capable Codex requests', async () => 
     const provider = openaiCodexSubscriptionProvider({ resolveOutputVerbosity: () => outputVerbosity })
     const profiles = new Map([['openai-codex', {
       provider: 'openai-codex', displayName: 'ChatGPT subscription', piProvider: provider,
-      configuredMaxTokens: new Map(), transport: 'sse', streamIdleTimeoutMs: 10_000,
+      configuredMaxTokens: new Map(), modelErrors: new Map(), transport: 'sse', streamIdleTimeoutMs: 10_000,
     }]])
     const adapter = new PiAiAdapter({ profiles: () => profiles, resolveApiKey: async () => jwt('account-verbosity') })
     const run = async model => {


### PR DESCRIPTION
Fixes #41.

On DSH `0.1.5-alpha.2`, resolving any ChatGPT subscription model throws `Cannot read properties of undefined (reading 'get')`. The host's `PiAiAdapter.modelOf()` now reads `profile.modelErrors.get(model)`, but this plugin constructs its own profile without going through DSH's settings-backed profile resolver.

This PR initializes that map so the host can resolve subscription models and prepare calls. It also supplies the same field in the five hand-built test profiles that were failing alpha acceptance. Existing OAuth refresh, context-window, Fast mode, and output-detail assertions remain intact.

### Changes

- Add `modelErrors: new Map()` to the runtime profile and regenerate the Host bundle through the normal build.
- Exercise resolution and call preparation for every advertised model through the adapter registered by the real plugin, asserting that model metadata does not read credentials.
- Complete the model-catalog and transport test fixtures for the alpha host contract.

No version bump, dependency changes, compatibility-range expansion, or unrelated generated assets are included. Formal alpha support remains subject to the maintainers' compatibility-release process.

### Validation

- `pnpm install --frozen-lockfile` completed.
- The new regression test was run against the installed `@deepseek-ai/dsh-llm-pi-ai@0.1.5-alpha.2`: removing the runtime fix reproduced the exact `undefined.get` error; restoring it passed.
- The model-catalog, transport, and plugin-integration suites against the actual alpha runtime passed **32/32**. Before updating the fixtures, the same five failures reported by alpha CI reproduced locally.
- Local `pnpm run check` on macOS (Node 25.2.1, pnpm 11.19.0): **312 passed, 2 failed, 26 skipped**. The two OAuth-network tests are the same pre-existing system-proxy-dependent failures documented on the previous revision; their expected direct routing is affected by this machine's enabled system proxy. They are outside this fix's scope.
- `pnpm run build` and `pnpm pack --pack-destination .artifacts` passed separately; the build produced no additional tracked changes.
- [Upstream CI](https://github.com/WSL043/dsh-codex-subscription/actions/runs/34430661372) passed on `fe7ba574937c534f503b14e1b54ce9d126fc5c51`: runtime behavior/candidate package, package/public-contract checks, and official installed-package acceptance for both `latest` and `alpha`. The optional Windows-manager job was correctly skipped by risk classification.

### Scope and privacy

The runtime change adds only an empty in-memory diagnostics map. It does not change authentication, networking, model capabilities, or provider selection. The new catalog regression test opens no model stream and consumes no subscription quota. Local GUI/model-call acceptance has not been claimed; the existing CI performs isolated installation, update, composition, Web startup, removal, and reinstallation on the official DSH channels.
